### PR TITLE
Additions to the gutter

### DIFF
--- a/packages/web-client/src/components/notebook/AiCell.tsx
+++ b/packages/web-client/src/components/notebook/AiCell.tsx
@@ -359,14 +359,18 @@ export const AiCell: React.FC<AiCellProps> = ({
             size="sm"
             onClick={executeAiPrompt}
             disabled={cell.executionState === 'running' || cell.executionState === 'queued'}
-            className="h-6 w-6 p-0 rounded-sm bg-white border-0 hover:bg-white"
+            className={`h-6 w-6 p-0 rounded-sm bg-white border-0 hover:bg-white transition-colors ${
+              autoFocus
+                ? 'text-purple-600'
+                : 'text-muted-foreground/40 hover:text-purple-600 group-hover:text-purple-600'
+            }`}
           >
             {cell.executionState === 'running' ? (
               <div className="animate-spin w-3 h-3 border border-purple-600 border-t-transparent rounded-full bg-white"></div>
             ) : cell.executionState === 'queued' ? (
               <div className="w-2 h-2 bg-purple-500 rounded-full"></div>
             ) : (
-              <Play className="h-3 w-3 text-purple-600" />
+              <Play className="h-3 w-3" />
             )}
           </Button>
         </div>

--- a/packages/web-client/src/components/notebook/Cell.tsx
+++ b/packages/web-client/src/components/notebook/Cell.tsx
@@ -375,8 +375,11 @@ export const Cell: React.FC<CellProps> = ({
               size="sm"
               onClick={executeCell}
               disabled={cell.executionState === 'running' || cell.executionState === 'queued'}
-              // className="h-6 w-6 p-0 rounded-sm bg-white border-0 hover:bg-white"
-              className="h-6 w-6 p-0 rounded-sm bg-white border-0 hover:bg-white"
+              className={`h-6 w-6 p-0 rounded-sm bg-white border-0 hover:bg-white transition-colors ${
+                autoFocus
+                  ? 'text-foreground'
+                  : 'text-muted-foreground/40 hover:text-foreground group-hover:text-foreground'
+              }`}
             >
               {cell.executionState === 'running' ? (
                 <div className="animate-spin w-3 h-3 border border-current border-t-transparent rounded-full bg-white"></div>

--- a/packages/web-client/src/components/notebook/SqlCell.tsx
+++ b/packages/web-client/src/components/notebook/SqlCell.tsx
@@ -315,14 +315,18 @@ export const SqlCell: React.FC<SqlCellProps> = ({
             size="sm"
             onClick={executeQuery}
             disabled={cell.executionState === 'running' || cell.executionState === 'queued'}
-            className="h-6 w-6 p-0 rounded-sm bg-white border-0 hover:bg-white"
+            className={`h-6 w-6 p-0 rounded-sm bg-white border-0 hover:bg-white transition-colors ${
+              autoFocus
+                ? 'text-blue-600'
+                : 'text-muted-foreground/40 hover:text-blue-600 group-hover:text-blue-600'
+            }`}
           >
             {cell.executionState === 'running' ? (
               <div className="animate-spin w-3 h-3 border border-blue-600 border-t-transparent rounded-full bg-white"></div>
             ) : cell.executionState === 'queued' ? (
               <div className="w-2 h-2 bg-blue-500 rounded-full"></div>
             ) : (
-              <Play className="h-3 w-3 text-blue-600" />
+              <Play className="h-3 w-3" />
             )}
           </Button>
         </div>


### PR DESCRIPTION
Add positioned play buttons with controlled left borders to prevent dangling borders when cells have no output. Play buttons are muted by default and become visible on cell focus/hover with appropriate theming for each cell type.

<img width="907" alt="image" src="https://github.com/user-attachments/assets/999547c1-e725-4480-a7be-0771759dea11" />

### Keyboard Navigation

![cell-nav](https://github.com/user-attachments/assets/865f8a99-2627-45b7-829e-8c5fe5a24717)
