### PR TITLE
Rely on `@runt` runtimes via deno and change terminology from kernel to runtimes

### DIFF
--- a/src/components/notebook/NotebookViewer.tsx
+++ b/src/components/notebook/NotebookViewer.tsx
@@ -23,6 +23,7 @@ export const NotebookViewer: React.FC<NotebookViewerProps> = ({ debugMode = fals
   const { store } = useStore()
   const cells = store.useQuery(queryDb(tables.cells.select().orderBy('position', 'asc'))) as CellData[]
   const notebooks = store.useQuery(queryDb(tables.notebook.select().limit(1))) as any[]
+  // TODO: Update schema to use runtime terminology (kernelSessions → runtimeSessions, KernelSessionData → RuntimeSessionData)
   const kernelSessions = store.useQuery(queryDb(tables.kernelSessions.select().where({ isActive: true }))) as KernelSessionData[]
   const notebook = notebooks[0]
 
@@ -306,7 +307,7 @@ export const NotebookViewer: React.FC<NotebookViewerProps> = ({ debugMode = fals
                 className="flex items-center gap-1 sm:gap-2"
               >
                 <Terminal className="h-3 sm:h-4 w-3 sm:w-4" />
-                <span className="capitalize text-xs sm:text-sm hidden sm:block">{notebook.kernelType}</span>
+                <span className="capitalize text-xs sm:text-sm hidden sm:block">{/* TODO: Update schema property kernelType → runtimeType */notebook.kernelType}</span>
                 <Circle
                   className={`h-2 w-2 fill-current ${
                     activeRuntime && runtimeHealth === 'healthy' ? 'text-green-500' :
@@ -403,7 +404,7 @@ export const NotebookViewer: React.FC<NotebookViewerProps> = ({ debugMode = fals
                   </div>
                   <div className="flex justify-between">
                     <span className="text-muted-foreground">Runtime Type:</span>
-                    <span>{activeRuntime.kernelType}</span>
+                    <span>{/* TODO: Update schema property kernelType → runtimeType */activeRuntime.kernelType}</span>
                   </div>
                   <div className="flex justify-between">
                     <span className="text-muted-foreground">Status:</span>


### PR DESCRIPTION
- Replace pnpm dev:runtime with deno run command for @runt/pyodide-runtime-agent
- Update UI text from 'Kernel Status' to 'Runtime Status'
- Change variable names from kernelCommand to runtimeCommand
- Update help text to use 'runtime' terminology instead of 'kernel'
- Runtime agent command now uses direct JSR package execution