### PR TITLE
Improved Keyboard Navigation

### DIFF
--- a/src/hooks/useCellKeyboardNavigation.ts
+++ b/src/hooks/useCellKeyboardNavigation.ts
@@ -66,8 +66,14 @@ export const useCellKeyboardNavigation = ({
       }
 
       // Handle execution shortcuts
-      if (e.key === "Enter" && (e.ctrlKey || e.metaKey)) {
-        // Ctrl/Cmd+Enter: Run cell and move to next (or create new cell if at end)
+      if (e.key === "Enter" && e.ctrlKey && !e.metaKey) {
+        // Ctrl+Enter: Run cell but stay in current cell
+        e.preventDefault();
+        onUpdateSource?.();
+        onExecute?.();
+        // Don't move to next cell - stay in current cell
+      } else if (e.key === "Enter" && e.metaKey && !e.ctrlKey) {
+        // Cmd+Enter: Run cell and move to next (or create new cell if at end)
         e.preventDefault();
         onUpdateSource?.();
         onExecute?.();


### PR DESCRIPTION
**Shift+Enter** now does the same thing people (like me!) are used to in chat apps - it creates newlines instead of submitting

**Ctrl-Enter:** _Execute_ cell and **stay in current cell**

**Cmd-Enter:** _Execute_ cell and **move to next cell**

**Arrow Keys:** Respect line boundaries before moving between cells