### PR TITLE
Just for fun: tailwind native ansi output

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "@radix-ui/react-tooltip": "^1.1.6",
     "@runt/schema": "jsr:^0.4.0",
     "@types/react-syntax-highlighter": "^15.5.13",
-    "ansi-to-react": "^6.1.6",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
@@ -61,7 +60,6 @@
     "react-dom": "19.0.0",
     "react-markdown": "^10.1.0",
     "react-syntax-highlighter": "^15.6.1",
-    "strip-ansi": "^7.1.0",
     "tailwind-merge": "^3.3.1",
     "tw-animate-css": "^1.3.4"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,9 +61,6 @@ importers:
       '@types/react-syntax-highlighter':
         specifier: ^15.5.13
         version: 15.5.13
-      ansi-to-react:
-        specifier: ^6.1.6
-        version: 6.1.6(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -94,9 +91,6 @@ importers:
       react-syntax-highlighter:
         specifier: ^15.6.1
         version: 15.6.1(react@19.0.0)
-      strip-ansi:
-        specifier: ^7.1.0
-        version: 7.1.0
       tailwind-merge:
         specifier: ^3.3.1
         version: 3.3.1

--- a/src/components/notebook/AnsiOutput.tsx
+++ b/src/components/notebook/AnsiOutput.tsx
@@ -45,7 +45,7 @@ const ANSI_BG_COLORS: Record<number, string> = {
   46: "bg-cyan-600",
   47: "bg-white",
 
-  // Bright background colors
+  // Bright background colors (codes 100-107)
   100: "bg-gray-500",
   101: "bg-red-400",
   102: "bg-green-400",
@@ -117,10 +117,12 @@ function parseAnsiEscapeSequences(text: string): AnsiSegment[] {
         currentSegment.strikethrough = false;
       } else if (code >= 30 && code <= 37) {
         // Standard foreground colors
-        currentSegment.fg = ANSI_COLORS[code - 30];
+        const colorKey = code - 30;
+        currentSegment.fg = ANSI_COLORS[colorKey];
       } else if (code >= 90 && code <= 97) {
         // Bright foreground colors
-        currentSegment.fg = ANSI_COLORS[code - 90 + 8];
+        const colorKey = code - 90 + 8;
+        currentSegment.fg = ANSI_COLORS[colorKey];
       } else if (code >= 40 && code <= 47) {
         // Standard background colors
         currentSegment.bg = ANSI_BG_COLORS[code];

--- a/src/components/notebook/AnsiOutput.tsx
+++ b/src/components/notebook/AnsiOutput.tsx
@@ -1,5 +1,178 @@
 import React from "react";
-import Ansi from "ansi-to-react";
+
+interface AnsiSegment {
+  text: string;
+  fg?: string;
+  bg?: string;
+  bold?: boolean;
+  dim?: boolean;
+  italic?: boolean;
+  underline?: boolean;
+  strikethrough?: boolean;
+}
+
+// Tailwind color mappings for standard ANSI colors
+const ANSI_COLORS: Record<number, string> = {
+  // Standard colors
+  0: "text-black", // black
+  1: "text-red-600", // red
+  2: "text-green-600", // green
+  3: "text-yellow-600", // yellow
+  4: "text-blue-600", // blue
+  5: "text-purple-600", // magenta
+  6: "text-cyan-600", // cyan
+  7: "text-white", // white
+
+  // Bright colors
+  8: "text-gray-500", // bright black (gray)
+  9: "text-red-400", // bright red
+  10: "text-green-400", // bright green
+  11: "text-yellow-400", // bright yellow
+  12: "text-blue-400", // bright blue
+  13: "text-purple-400", // bright magenta
+  14: "text-cyan-400", // bright cyan
+  15: "text-gray-100", // bright white
+};
+
+const ANSI_BG_COLORS: Record<number, string> = {
+  // Standard background colors
+  40: "bg-black",
+  41: "bg-red-600",
+  42: "bg-green-600",
+  43: "bg-yellow-600",
+  44: "bg-blue-600",
+  45: "bg-purple-600",
+  46: "bg-cyan-600",
+  47: "bg-white",
+
+  // Bright background colors
+  100: "bg-gray-500",
+  101: "bg-red-400",
+  102: "bg-green-400",
+  103: "bg-yellow-400",
+  104: "bg-blue-400",
+  105: "bg-purple-400",
+  106: "bg-cyan-400",
+  107: "bg-gray-100",
+};
+
+function parseAnsiEscapeSequences(text: string): AnsiSegment[] {
+  if (!text) return [];
+
+  const segments: AnsiSegment[] = [];
+  let currentSegment: AnsiSegment = { text: "" };
+
+  // ANSI escape sequence regex: \x1b[...m
+  const ansiRegex = /\x1b\[([0-9;]*)m/g;
+  let lastIndex = 0;
+  let match;
+
+  while ((match = ansiRegex.exec(text)) !== null) {
+    // Add text before this escape sequence
+    const textBefore = text.slice(lastIndex, match.index);
+    if (textBefore) {
+      currentSegment.text += textBefore;
+    }
+
+    // If we have accumulated text, push the current segment
+    if (currentSegment.text) {
+      segments.push({ ...currentSegment });
+      currentSegment = {
+        text: "",
+        fg: currentSegment.fg,
+        bg: currentSegment.bg,
+        bold: currentSegment.bold,
+        dim: currentSegment.dim,
+        italic: currentSegment.italic,
+        underline: currentSegment.underline,
+        strikethrough: currentSegment.strikethrough,
+      };
+    }
+
+    // Parse the escape sequence
+    const codes = match[1] ? match[1].split(";").map(Number) : [0];
+
+    for (const code of codes) {
+      if (code === 0) {
+        // Reset all formatting
+        currentSegment = { text: "" };
+      } else if (code === 1) {
+        currentSegment.bold = true;
+      } else if (code === 2) {
+        currentSegment.dim = true;
+      } else if (code === 3) {
+        currentSegment.italic = true;
+      } else if (code === 4) {
+        currentSegment.underline = true;
+      } else if (code === 9) {
+        currentSegment.strikethrough = true;
+      } else if (code === 22) {
+        currentSegment.bold = false;
+        currentSegment.dim = false;
+      } else if (code === 23) {
+        currentSegment.italic = false;
+      } else if (code === 24) {
+        currentSegment.underline = false;
+      } else if (code === 29) {
+        currentSegment.strikethrough = false;
+      } else if (code >= 30 && code <= 37) {
+        // Standard foreground colors
+        currentSegment.fg = ANSI_COLORS[code - 30];
+      } else if (code >= 90 && code <= 97) {
+        // Bright foreground colors
+        currentSegment.fg = ANSI_COLORS[code - 90 + 8];
+      } else if (code >= 40 && code <= 47) {
+        // Standard background colors
+        currentSegment.bg = ANSI_BG_COLORS[code];
+      } else if (code >= 100 && code <= 107) {
+        // Bright background colors
+        currentSegment.bg = ANSI_BG_COLORS[code];
+      } else if (code === 39) {
+        // Default foreground color
+        currentSegment.fg = undefined;
+      } else if (code === 49) {
+        // Default background color
+        currentSegment.bg = undefined;
+      }
+    }
+
+    lastIndex = ansiRegex.lastIndex;
+  }
+
+  // Add remaining text
+  const remainingText = text.slice(lastIndex);
+  if (remainingText) {
+    currentSegment.text += remainingText;
+  }
+
+  if (currentSegment.text) {
+    segments.push(currentSegment);
+  }
+
+  return segments;
+}
+
+function fixBackspace(text: string): string {
+  // Handle backspace characters like Jupyter does
+  let result = text;
+  let prev;
+  do {
+    prev = result;
+    result = result.replace(/[^\n]\x08/gm, "");
+  } while (result.length < prev.length);
+  return result;
+}
+
+function fixCarriageReturn(text: string): string {
+  // Handle carriage returns - split by \r and keep only the last part of each line
+  return text
+    .split("\n")
+    .map((line) => {
+      const parts = line.split("\r");
+      return parts[parts.length - 1];
+    })
+    .join("\n");
+}
 
 interface AnsiOutputProps {
   children: string;
@@ -7,15 +180,6 @@ interface AnsiOutputProps {
   isError?: boolean;
 }
 
-/**
- * AnsiOutput component for rendering ANSI escape sequences as colored text
- *
- * This component preserves the beautiful colored output that developers expect
- * while using ansi-to-react to convert ANSI codes to styled React elements.
- *
- * For AI context, use cleanForAI() utility to strip ANSI codes.
- * For user display, use this component to render the colors.
- */
 export const AnsiOutput: React.FC<AnsiOutputProps> = ({
   children,
   className = "",
@@ -25,19 +189,51 @@ export const AnsiOutput: React.FC<AnsiOutputProps> = ({
     return null;
   }
 
+  // Clean up the text
+  let cleanText = fixBackspace(children);
+  cleanText = fixCarriageReturn(cleanText);
+
+  // Parse ANSI sequences
+  const segments = parseAnsiEscapeSequences(cleanText);
+
   const baseClasses = `font-mono text-sm whitespace-pre-wrap leading-relaxed ${className}`;
   const errorClasses = isError ? "text-red-600" : "";
   const finalClasses = `${baseClasses} ${errorClasses}`.trim();
 
   return (
     <div className={finalClasses}>
-      <Ansi useClasses={false}>{children}</Ansi>
+      {segments.map((segment, index) => {
+        if (!segment.text) return null;
+
+        const classes = [];
+
+        // Apply colors (only if not in error mode, which overrides)
+        if (!isError) {
+          if (segment.fg) classes.push(segment.fg);
+          if (segment.bg) classes.push(segment.bg);
+        }
+
+        // Apply text decorations
+        if (segment.bold) classes.push("font-bold");
+        if (segment.dim) classes.push("opacity-50");
+        if (segment.italic) classes.push("italic");
+        if (segment.underline) classes.push("underline");
+        if (segment.strikethrough) classes.push("line-through");
+
+        const segmentClasses = classes.join(" ");
+
+        return (
+          <span key={index} className={segmentClasses || undefined}>
+            {segment.text}
+          </span>
+        );
+      })}
     </div>
   );
 };
 
 /**
- * AnsiStreamOutput component specifically for stdout/stderr rendering
+ * TailwindAnsiStreamOutput component specifically for stdout/stderr rendering
  */
 export const AnsiStreamOutput: React.FC<{
   text: string;
@@ -55,7 +251,7 @@ export const AnsiStreamOutput: React.FC<{
 };
 
 /**
- * AnsiErrorOutput component specifically for error messages and tracebacks
+ * TailwindAnsiErrorOutput component specifically for error messages and tracebacks
  */
 export const AnsiErrorOutput: React.FC<{
   ename?: string;

--- a/src/util/ansi-cleaner.ts
+++ b/src/util/ansi-cleaner.ts
@@ -1,4 +1,4 @@
-import stripAnsi from "strip-ansi";
+// Simple ANSI cleaning using regex - runtime agent handles this for AI context
 
 /**
  * Cleans ANSI escape codes from text for AI context consumption
@@ -15,7 +15,7 @@ export function cleanForAI(text: string): string {
     return text;
   }
 
-  return stripAnsi(text);
+  return text.replace(/\x1b\[[0-9;]*m/g, "");
 }
 
 /**


### PR DESCRIPTION
I wanted to see what it would look like if we eliminated the following dependencies:

* react-to-ansi (written by me + others for nteract, now used by many projects)
* escape-carriage (written by @lgeiger for nteract, now used by a bajillion projects)
* anser

and replaced it with 100% tailwind CSS classes

<img width="974" alt="image" src="https://github.com/user-attachments/assets/79b29c2b-0357-4310-8c4f-a0657f2ae262" />

Less code to initialize. Reduces bundle size by 6kb but probably missing colors.