### PR TITLE
Fix CodeMirror focus management and cell navigation jank

### DIFF
--- a/src/components/notebook/AiCell.tsx
+++ b/src/components/notebook/AiCell.tsx
@@ -89,11 +89,8 @@ export const AiCell: React.FC<AiCellProps> = ({
     // Use localSource instead of cell.source to get the current typed content
     const sourceToExecute = localSource || cell.source;
     if (!sourceToExecute?.trim()) {
-      console.log("No prompt to execute");
       return;
     }
-
-    console.log("🤖 Executing AI prompt via execution queue:", cell.id);
 
     try {
       // Clear previous outputs first
@@ -120,8 +117,6 @@ export const AiCell: React.FC<AiCellProps> = ({
           priority: 1,
         })
       );
-
-      console.log("✅ AI execution queued with ID:", queueId);
 
       // The kernel service will now:
       // 1. See the pending execution in the queue

--- a/src/components/notebook/Cell.tsx
+++ b/src/components/notebook/Cell.tsx
@@ -172,11 +172,8 @@ export const Cell: React.FC<CellProps> = ({
     // Use localSource instead of cell.source to get the current typed content
     const sourceToExecute = localSource || cell.source;
     if (!sourceToExecute?.trim()) {
-      console.log("No code to execute");
       return;
     }
-
-    console.log("🚀 Executing cell via execution queue:", cell.id);
 
     try {
       // Clear previous outputs first
@@ -203,8 +200,6 @@ export const Cell: React.FC<CellProps> = ({
           priority: 1,
         })
       );
-
-      console.log("✅ Execution queued with ID:", queueId);
 
       // The kernel service will now:
       // 1. See the pending execution in the queue

--- a/src/components/notebook/CodeMirror.tsx
+++ b/src/components/notebook/CodeMirror.tsx
@@ -6,7 +6,7 @@ import {
 } from "@codemirror/view";
 import { githubLight } from "@uiw/codemirror-theme-github";
 import { basicSetup } from "codemirror";
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useMemo, useCallback } from "react";
 
 import { markdown } from "@codemirror/lang-markdown";
 import { CellBase } from "./CellBase.js";
@@ -15,10 +15,7 @@ import { SupportedLanguage } from "@/types/misc.js";
 import { sql } from "@codemirror/lang-sql";
 import { useCodeMirror } from "@uiw/react-codemirror";
 
-// Putting basicSetup last so we can override the default keymap
-const extensions = [basicSetup, githubLight];
-
-// ---
+const baseExtensions = [basicSetup, githubLight];
 
 type CodeMirrorEditorProps = {
   value: string;
@@ -56,19 +53,36 @@ export const CodeMirrorEditor: React.FC<CodeMirrorEditorProps> = ({
 }) => {
   const editorRef = useRef<HTMLDivElement | null>(null);
 
-  const { setContainer } = useCodeMirror({
-    container: editorRef.current,
-    extensions: [
-      keymap.of(keyMap || []),
-      ...extensions,
-      languageExtension(language),
-      placeholder ? placeholderExt(placeholder) : [],
-    ],
-    basicSetup: false,
-    value,
-    onChange: (val) => {
+  const langExtension = useMemo(() => languageExtension(language), [language]);
+
+  const extensions = useMemo(() => {
+    const exts = [keymap.of(keyMap || []), ...baseExtensions, langExtension];
+
+    if (placeholder) {
+      exts.push(placeholderExt(placeholder));
+    }
+
+    return exts;
+  }, [keyMap, langExtension, placeholder]);
+
+  const handleChange = useCallback(
+    (val: string) => {
       onValueChange(val);
     },
+    [onValueChange]
+  );
+
+  const handleFocus = useCallback(() => {
+    editorRef.current?.scrollIntoView({ block: "nearest" });
+    onFocus?.();
+  }, [onFocus]);
+
+  const { setContainer } = useCodeMirror({
+    container: editorRef.current,
+    extensions,
+    basicSetup: false,
+    value,
+    onChange: handleChange,
     autoFocus,
   });
 
@@ -76,20 +90,11 @@ export const CodeMirrorEditor: React.FC<CodeMirrorEditorProps> = ({
     if (editorRef.current) {
       setContainer(editorRef.current);
     }
-  }, [editorRef.current]);
+  }, [setContainer]);
 
   return (
     <CellBase isMaximized={isMaximized} asChild>
-      <div
-        ref={editorRef}
-        onBlur={() => {
-          onBlur?.();
-        }}
-        onFocus={() => {
-          editorRef.current?.scrollIntoView({ block: "nearest" });
-          onFocus?.();
-        }}
-      />
+      <div ref={editorRef} onBlur={onBlur} onFocus={handleFocus} />
     </CellBase>
   );
 };

--- a/src/components/notebook/CodeMirror.tsx
+++ b/src/components/notebook/CodeMirror.tsx
@@ -67,7 +67,6 @@ export const CodeMirrorEditor: React.FC<CodeMirrorEditorProps> = ({
     basicSetup: false,
     value,
     onChange: (val) => {
-      console.log("val:", val);
       onValueChange(val);
     },
     autoFocus,
@@ -84,11 +83,9 @@ export const CodeMirrorEditor: React.FC<CodeMirrorEditorProps> = ({
       <div
         ref={editorRef}
         onBlur={() => {
-          console.log("onBlur", editorRef.current);
           onBlur?.();
         }}
         onFocus={() => {
-          console.log("onFocus", editorRef.current);
           editorRef.current?.scrollIntoView({ block: "nearest" });
           onFocus?.();
         }}

--- a/src/components/notebook/CodeMirror.tsx
+++ b/src/components/notebook/CodeMirror.tsx
@@ -77,13 +77,14 @@ export const CodeMirrorEditor: React.FC<CodeMirrorEditorProps> = ({
     onFocus?.();
   }, [onFocus]);
 
-  const { setContainer } = useCodeMirror({
+  const { setContainer, view } = useCodeMirror({
     container: editorRef.current,
     extensions,
     basicSetup: false,
     value,
     onChange: handleChange,
-    autoFocus,
+    // Handle focus manually
+    autoFocus: false,
   });
 
   useEffect(() => {
@@ -91,6 +92,15 @@ export const CodeMirrorEditor: React.FC<CodeMirrorEditorProps> = ({
       setContainer(editorRef.current);
     }
   }, [setContainer]);
+
+  useEffect(() => {
+    if (autoFocus && view) {
+      // Defer focus until after the editor has been mounted
+      setTimeout(() => {
+        view.focus();
+      }, 0);
+    }
+  }, [autoFocus, view]);
 
   return (
     <CellBase isMaximized={isMaximized} asChild>

--- a/src/components/notebook/SqlCell.tsx
+++ b/src/components/notebook/SqlCell.tsx
@@ -76,7 +76,6 @@ export const SqlCell: React.FC<SqlCellProps> = ({
   const executeQuery = useCallback(() => {
     if (!cell.sqlConnectionId) {
       // TODO: Show connection selection modal
-      console.log("No connection selected for SQL cell");
       return;
     }
 

--- a/src/hooks/useCellContent.ts
+++ b/src/hooks/useCellContent.ts
@@ -22,7 +22,6 @@ export const useCellContent = ({
   }, [initialSource]);
 
   const updateSource = useCallback(() => {
-    console.log("updateSource", localSource, initialSource);
     if (localSource !== initialSource) {
       store.commit(
         events.cellSourceChanged({

--- a/src/hooks/useCellKeyboardNavigation.ts
+++ b/src/hooks/useCellKeyboardNavigation.ts
@@ -47,7 +47,10 @@ export const useCellKeyboardNavigation = ({
 
           if (cursorPos === docLength) {
             onFocusNext?.();
+            // Prevent CodeMirror from handling
+            return true;
           }
+          // Pass on to CodeMirror
           return false;
         },
       },
@@ -60,7 +63,10 @@ export const useCellKeyboardNavigation = ({
 
           if (cursorPos === 0) {
             onFocusPrevious?.();
+            // Prevent CodeMirror from handling
+            return true;
           }
+          // Pass on to CodeMirror
           return false;
         },
       },
@@ -81,7 +87,7 @@ export const useCellKeyboardNavigation = ({
       },
     ];
     return map;
-  }, [onExecute]);
+  }, [onExecute, onFocusNext, onFocusPrevious, onDeleteCell, onUpdateSource]);
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLTextAreaElement>) => {


### PR DESCRIPTION
Problem: Navigating between cells felt sluggish and would jump to the wrong cells, as if CodeMirror was hijacking the active cell and consuming more events than it needed to.

Solution: Focus CodeMirror when autoFocus prop changes so there wouldn't be a race condition between React state and CodeMirror's internal focus handling. For the previous and next cell keymap returns, return true when arrow keys trigger cell nav so that CodeMirror isn't also processing the key.

For good measure, I also memoized the extensions array and callbacks to prevent unnecessary re-renders.