### PR TITLE
Remove line numbers and borders for cleaner CodeMirror interface

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,11 +36,14 @@
     "start": "echo 'Use pnpm dev for web client and pnpm dev:sync for sync worker in separate terminals'"
   },
   "dependencies": {
-    "@codemirror/basic-setup": "^0.20.0",
+    "@codemirror/autocomplete": "^6.18.6",
     "@codemirror/commands": "^6.8.1",
     "@codemirror/lang-markdown": "^6.3.3",
     "@codemirror/lang-python": "^6.2.1",
     "@codemirror/lang-sql": "^6.9.0",
+    "@codemirror/language": "^6.11.2",
+    "@codemirror/lint": "^6.8.5",
+    "@codemirror/search": "^6.5.11",
     "@codemirror/state": "^6.5.2",
     "@codemirror/view": "^6.38.0",
     "@livestore/adapter-web": "^0.3.1",
@@ -62,7 +65,6 @@
     "ansi-to-react": "^6.1.6",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "codemirror": "^6.0.2",
     "date-fns": "^4.1.0",
     "effect": "3.15.5",
     "js-cookie": "^3.0.5",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "@codemirror/lang-sql": "^6.9.0",
     "@codemirror/language": "^6.11.2",
     "@codemirror/lint": "^6.8.5",
-    "@codemirror/search": "^6.5.11",
     "@codemirror/state": "^6.5.2",
     "@codemirror/view": "^6.38.0",
     "@livestore/adapter-web": "^0.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,9 +19,9 @@ importers:
 
   .:
     dependencies:
-      '@codemirror/basic-setup':
-        specifier: ^0.20.0
-        version: 0.20.0
+      '@codemirror/autocomplete':
+        specifier: ^6.18.6
+        version: 6.18.6
       '@codemirror/commands':
         specifier: ^6.8.1
         version: 6.8.1
@@ -34,6 +34,15 @@ importers:
       '@codemirror/lang-sql':
         specifier: ^6.9.0
         version: 6.9.0
+      '@codemirror/language':
+        specifier: ^6.11.2
+        version: 6.11.2
+      '@codemirror/lint':
+        specifier: ^6.8.5
+        version: 6.8.5
+      '@codemirror/search':
+        specifier: ^6.5.11
+        version: 6.5.11
       '@codemirror/state':
         specifier: ^6.5.2
         version: 6.5.2
@@ -97,9 +106,6 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
-      codemirror:
-        specifier: ^6.0.2
-        version: 6.0.2
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
@@ -532,18 +538,8 @@ packages:
   '@cloudflare/workers-types@4.20250613.0':
     resolution: {integrity: sha512-upH6pxh43ph9293aXVgEp/0ODhyT3deRdlL0NEe4eJJdgoSAJxWj0c2ASZHs3awOaItRTxTxo7GZk1d6wolPKQ==}
 
-  '@codemirror/autocomplete@0.20.3':
-    resolution: {integrity: sha512-lYB+NPGP+LEzAudkWhLfMxhTrxtLILGl938w+RcFrGdrIc54A+UgmCoz+McE3IYRFp4xyQcL4uFJwo+93YdgHw==}
-
   '@codemirror/autocomplete@6.18.6':
     resolution: {integrity: sha512-PHHBXFomUs5DF+9tCOM/UoW6XQ4R44lLNNhRaW9PKPTU0D7lIjRg3ElxaJnTwsl/oHiR93WSXDBrekhoUGCPtg==}
-
-  '@codemirror/basic-setup@0.20.0':
-    resolution: {integrity: sha512-W/ERKMLErWkrVLyP5I8Yh8PXl4r+WFNkdYVSzkXYPQv2RMPSkWpr2BgggiSJ8AHF/q3GuApncDD8I4BZz65fyg==}
-    deprecated: In version 6.0, this package has been renamed to just 'codemirror'
-
-  '@codemirror/commands@0.20.0':
-    resolution: {integrity: sha512-v9L5NNVA+A9R6zaFvaTbxs30kc69F6BkOoiEbeFw4m4I0exmDEKBILN6mK+GksJtvTzGBxvhAPlVFTdQW8GB7Q==}
 
   '@codemirror/commands@6.8.1':
     resolution: {integrity: sha512-KlGVYufHMQzxbdQONiLyGQDUW0itrLZwq3CcY7xpv9ZLRHqzkBSoteocBHtMCoY7/Ci4xhzSrToIeLg7FxHuaw==}
@@ -566,35 +562,20 @@ packages:
   '@codemirror/lang-sql@6.9.0':
     resolution: {integrity: sha512-xmtpWqKSgum1B1J3Ro6rf7nuPqf2+kJQg5SjrofCAcyCThOe0ihSktSoXfXuhQBnwx1QbmreBbLJM5Jru6zitg==}
 
-  '@codemirror/language@0.20.2':
-    resolution: {integrity: sha512-WB3Bnuusw0xhVvhBocieYKwJm04SOk5bPoOEYksVHKHcGHFOaYaw+eZVxR4gIqMMcGzOIUil0FsCmFk8yrhHpw==}
-
   '@codemirror/language@6.11.2':
     resolution: {integrity: sha512-p44TsNArL4IVXDTbapUmEkAlvWs2CFQbcfc0ymDsis1kH2wh0gcY96AS29c/vp2d0y2Tquk1EDSaawpzilUiAw==}
-
-  '@codemirror/lint@0.20.3':
-    resolution: {integrity: sha512-06xUScbbspZ8mKoODQCEx6hz1bjaq9m8W8DxdycWARMiiX1wMtfCh/MoHpaL7ws/KUMwlsFFfp2qhm32oaCvVA==}
 
   '@codemirror/lint@6.8.5':
     resolution: {integrity: sha512-s3n3KisH7dx3vsoeGMxsbRAgKe4O1vbrnKBClm99PU0fWxmxsx5rR2PfqQgIt+2MMJBHbiJ5rfIdLYfB9NNvsA==}
 
-  '@codemirror/search@0.20.1':
-    resolution: {integrity: sha512-ROe6gRboQU5E4z6GAkNa2kxhXqsGNbeLEisbvzbOeB7nuDYXUZ70vGIgmqPu0tB+1M3F9yWk6W8k2vrFpJaD4Q==}
-
   '@codemirror/search@6.5.11':
     resolution: {integrity: sha512-KmWepDE6jUdL6n8cAAqIpRmLPBZ5ZKnicE8oGU/s3QrAVID+0VhLFrzUucVKHG5035/BSykhExDL/Xm7dHthiA==}
-
-  '@codemirror/state@0.20.1':
-    resolution: {integrity: sha512-ms0tlV5A02OK0pFvTtSUGMLkoarzh1F8mr6jy1cD7ucSC2X/VLHtQCxfhdSEGqTYlQF2hoZtmLv+amqhdgbwjQ==}
 
   '@codemirror/state@6.5.2':
     resolution: {integrity: sha512-FVqsPqtPWKVVL3dPSxy8wEF/ymIEuVzF1PK3VbUgrxXpJUSHQWWZz4JMToquRxnkw+36LTamCZG2iua2Ptq0fA==}
 
   '@codemirror/theme-one-dark@6.1.3':
     resolution: {integrity: sha512-NzBdIvEJmx6fjeremiGp3t/okrLPYT0d9orIc7AFun8oZcRk58aejkqhv6spnz4MLAevrKNPMQYXEWMg4s+sKA==}
-
-  '@codemirror/view@0.20.7':
-    resolution: {integrity: sha512-pqEPCb9QFTOtHgAH5XU/oVy9UR/Anj6r+tG5CRmkNVcqSKEPmBU05WtN/jxJCFZBXf6HumzWC9ydE4qstO3TxQ==}
 
   '@codemirror/view@6.38.0':
     resolution: {integrity: sha512-yvSchUwHOdupXkd7xJ0ob36jdsSR/I+/C+VbY0ffBiL5NiSTEBDfB1ZGWbbIlDd5xgdUkody+lukAdOxYrOBeg==}
@@ -1197,17 +1178,11 @@ packages:
   '@jsr/runt__schema@0.4.0':
     resolution: {integrity: sha512-rb4hNlzUp9taxxpBI4MpBZW0sydS5/biaVfSDukzvvrze1NtuIbTR/MCywjspZ5qBUxhKXerEHe/Ftw6M77WRQ==, tarball: https://npm.jsr.io/~/11/@jsr/runt__schema/0.4.0.tgz}
 
-  '@lezer/common@0.16.1':
-    resolution: {integrity: sha512-qPmG7YTZ6lATyTOAWf8vXE+iRrt1NJd4cm2nJHK+v7X9TsOF6+HtuU/ctaZy2RCrluxDb89hI6KWQ5LfQGQWuA==}
-
   '@lezer/common@1.2.3':
     resolution: {integrity: sha512-w7ojc8ejBqr2REPsWxJjrMFsA/ysDCFICn8zEOR9mrqzOu2amhITYuLD8ag6XZf0CFXDrhKqw7+tW8cX66NaDA==}
 
   '@lezer/css@1.2.1':
     resolution: {integrity: sha512-2F5tOqzKEKbCUNraIXc0f6HKeyKlmMWJnBB0i4XW6dJgssrZO/YlZ2pY5xgyqDleqqhiNJ3dQhbrV2aClZQMvg==}
-
-  '@lezer/highlight@0.16.0':
-    resolution: {integrity: sha512-iE5f4flHlJ1g1clOStvXNLbORJoiW4Kytso6ubfYzHnaNo/eo5SKhxs4wv/rtvwZQeZrK3we8S9SyA7OGOoRKQ==}
 
   '@lezer/highlight@1.2.1':
     resolution: {integrity: sha512-Z5duk4RN/3zuVO7Jq0pGLJ3qynpxUVsh7IbUbGj88+uV2ApSAn6kWg2au3iJb+0Zi7kKtqffIESgNcRXWZWmSA==}
@@ -1217,9 +1192,6 @@ packages:
 
   '@lezer/javascript@1.5.1':
     resolution: {integrity: sha512-ATOImjeVJuvgm3JQ/bpo2Tmv55HSScE2MTPnKRMRIPx2cLhHGyX2VnqpHhtIV1tVzIjZDbcWQm+NCTF40ggZVw==}
-
-  '@lezer/lr@0.16.3':
-    resolution: {integrity: sha512-pau7um4eAw94BEuuShUIeQDTf3k4Wt6oIUOYxMmkZgDHdqtIcxWND4LRxi8nI9KuT4I1bXQv67BCapkxt7Ywqw==}
 
   '@lezer/lr@1.4.2':
     resolution: {integrity: sha512-pu0K1jCIdnQ12aWNaAVU5bzi7Bd1w54J3ECgANPmYLtQKP0HBj2cE/5coBD66MT10xbtIuUr7tg0Shbsvk0mDA==}
@@ -3876,36 +3848,12 @@ snapshots:
 
   '@cloudflare/workers-types@4.20250613.0': {}
 
-  '@codemirror/autocomplete@0.20.3':
-    dependencies:
-      '@codemirror/language': 0.20.2
-      '@codemirror/state': 0.20.1
-      '@codemirror/view': 0.20.7
-      '@lezer/common': 0.16.1
-
   '@codemirror/autocomplete@6.18.6':
     dependencies:
       '@codemirror/language': 6.11.2
       '@codemirror/state': 6.5.2
       '@codemirror/view': 6.38.0
       '@lezer/common': 1.2.3
-
-  '@codemirror/basic-setup@0.20.0':
-    dependencies:
-      '@codemirror/autocomplete': 0.20.3
-      '@codemirror/commands': 0.20.0
-      '@codemirror/language': 0.20.2
-      '@codemirror/lint': 0.20.3
-      '@codemirror/search': 0.20.1
-      '@codemirror/state': 0.20.1
-      '@codemirror/view': 0.20.7
-
-  '@codemirror/commands@0.20.0':
-    dependencies:
-      '@codemirror/language': 0.20.2
-      '@codemirror/state': 0.20.1
-      '@codemirror/view': 0.20.7
-      '@lezer/common': 0.16.1
 
   '@codemirror/commands@6.8.1':
     dependencies:
@@ -3971,15 +3919,6 @@ snapshots:
       '@lezer/highlight': 1.2.1
       '@lezer/lr': 1.4.2
 
-  '@codemirror/language@0.20.2':
-    dependencies:
-      '@codemirror/state': 0.20.1
-      '@codemirror/view': 0.20.7
-      '@lezer/common': 0.16.1
-      '@lezer/highlight': 0.16.0
-      '@lezer/lr': 0.16.3
-      style-mod: 4.1.2
-
   '@codemirror/language@6.11.2':
     dependencies:
       '@codemirror/state': 6.5.2
@@ -3989,22 +3928,10 @@ snapshots:
       '@lezer/lr': 1.4.2
       style-mod: 4.1.2
 
-  '@codemirror/lint@0.20.3':
-    dependencies:
-      '@codemirror/state': 0.20.1
-      '@codemirror/view': 0.20.7
-      crelt: 1.0.6
-
   '@codemirror/lint@6.8.5':
     dependencies:
       '@codemirror/state': 6.5.2
       '@codemirror/view': 6.38.0
-      crelt: 1.0.6
-
-  '@codemirror/search@0.20.1':
-    dependencies:
-      '@codemirror/state': 0.20.1
-      '@codemirror/view': 0.20.7
       crelt: 1.0.6
 
   '@codemirror/search@6.5.11':
@@ -4012,8 +3939,6 @@ snapshots:
       '@codemirror/state': 6.5.2
       '@codemirror/view': 6.38.0
       crelt: 1.0.6
-
-  '@codemirror/state@0.20.1': {}
 
   '@codemirror/state@6.5.2':
     dependencies:
@@ -4025,12 +3950,6 @@ snapshots:
       '@codemirror/state': 6.5.2
       '@codemirror/view': 6.38.0
       '@lezer/highlight': 1.2.1
-
-  '@codemirror/view@0.20.7':
-    dependencies:
-      '@codemirror/state': 0.20.1
-      style-mod: 4.1.2
-      w3c-keyname: 2.2.8
 
   '@codemirror/view@6.38.0':
     dependencies:
@@ -4480,8 +4399,6 @@ snapshots:
       - '@opentelemetry/resources'
       - effect
 
-  '@lezer/common@0.16.1': {}
-
   '@lezer/common@1.2.3': {}
 
   '@lezer/css@1.2.1':
@@ -4489,10 +4406,6 @@ snapshots:
       '@lezer/common': 1.2.3
       '@lezer/highlight': 1.2.1
       '@lezer/lr': 1.4.2
-
-  '@lezer/highlight@0.16.0':
-    dependencies:
-      '@lezer/common': 0.16.1
 
   '@lezer/highlight@1.2.1':
     dependencies:
@@ -4509,10 +4422,6 @@ snapshots:
       '@lezer/common': 1.2.3
       '@lezer/highlight': 1.2.1
       '@lezer/lr': 1.4.2
-
-  '@lezer/lr@0.16.3':
-    dependencies:
-      '@lezer/common': 0.16.1
 
   '@lezer/lr@1.4.2':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,9 +40,6 @@ importers:
       '@codemirror/lint':
         specifier: ^6.8.5
         version: 6.8.5
-      '@codemirror/search':
-        specifier: ^6.5.11
-        version: 6.5.11
       '@codemirror/state':
         specifier: ^6.5.2
         version: 6.5.2

--- a/src/components/notebook/CodeMirror.tsx
+++ b/src/components/notebook/CodeMirror.tsx
@@ -4,9 +4,13 @@ import {
   KeyBinding,
   keymap,
   placeholder as placeholderExt,
+  highlightSpecialChars,
+  drawSelection,
+  dropCursor,
+  rectangularSelection,
+  crosshairCursor,
 } from "@codemirror/view";
 import { githubLight } from "@uiw/codemirror-theme-github";
-import { basicSetup } from "codemirror";
 import { useEffect, useRef, useMemo, useCallback } from "react";
 
 import { markdown } from "@codemirror/lang-markdown";
@@ -15,9 +19,64 @@ import { CellBase } from "./CellBase.js";
 import { SupportedLanguage } from "@/types/misc.js";
 import { sql } from "@codemirror/lang-sql";
 import { useCodeMirror } from "@uiw/react-codemirror";
+import { EditorState } from "@codemirror/state";
+import {
+  defaultHighlightStyle,
+  syntaxHighlighting,
+  indentOnInput,
+  bracketMatching,
+} from "@codemirror/language";
+import { defaultKeymap, history, historyKeymap } from "@codemirror/commands";
+import { searchKeymap, highlightSelectionMatches } from "@codemirror/search";
+import {
+  autocompletion,
+  completionKeymap,
+  closeBrackets,
+  closeBracketsKeymap,
+} from "@codemirror/autocomplete";
+import { lintKeymap } from "@codemirror/lint";
+
+// Custom setup without line numbers and gutters
+const customSetup = [
+  // Replace non-printable characters with placeholders
+  highlightSpecialChars(),
+  // The undo history
+  history(),
+  // Replace native cursor/selection with our own
+  drawSelection(),
+  // Show a drop cursor when dragging over the editor
+  dropCursor(),
+  // Allow multiple cursors/selections
+  EditorState.allowMultipleSelections.of(true),
+  // Re-indent lines when typing specific input
+  indentOnInput(),
+  // Highlight syntax with a default style
+  syntaxHighlighting(defaultHighlightStyle),
+  // Highlight matching brackets near cursor
+  bracketMatching(),
+  // Automatically close brackets
+  closeBrackets(),
+  // Load the autocompletion system
+  autocompletion(),
+  // Allow alt-drag to select rectangular regions
+  rectangularSelection(),
+  // Show a crosshair cursor when rectangular selecting
+  crosshairCursor(),
+  // Highlight matching search results
+  highlightSelectionMatches(),
+  // Key bindings
+  keymap.of([
+    ...closeBracketsKeymap,
+    ...defaultKeymap,
+    ...searchKeymap,
+    ...historyKeymap,
+    ...completionKeymap,
+    ...lintKeymap,
+  ]),
+];
 
 const baseExtensions = [
-  basicSetup,
+  ...customSetup,
   githubLight,
   EditorView.theme({
     // Disable active line highlighting
@@ -27,12 +86,37 @@ const baseExtensions = [
     ".cm-focused .cm-activeLine": {
       backgroundColor: "transparent !important",
     },
-    // Disable gutter active line highlighting
-    ".cm-activeLineGutter": {
-      backgroundColor: "transparent !important",
+    // Remove any gutter styling
+    ".cm-gutters": {
+      display: "none !important",
     },
-    ".cm-focused .cm-activeLineGutter": {
-      backgroundColor: "transparent !important",
+    // Ensure editor content takes full width
+    ".cm-content": {
+      padding: "0 !important",
+    },
+    // Remove all borders and outlines from editor
+    ".cm-editor": {
+      border: "none !important",
+      outline: "none !important",
+    },
+    ".cm-focused": {
+      outline: "none !important",
+      border: "none !important",
+    },
+    ".cm-focused.cm-editor": {
+      outline: "none !important",
+      border: "none !important",
+      boxShadow: "none !important",
+    },
+    // Override any theme borders
+    "&.cm-focused": {
+      outline: "none !important",
+      border: "none !important",
+    },
+    // Remove any dotted borders from focus states
+    ".cm-focused .cm-scroller": {
+      outline: "none !important",
+      border: "none !important",
     },
   }),
 ];

--- a/src/components/notebook/CodeMirror.tsx
+++ b/src/components/notebook/CodeMirror.tsx
@@ -27,7 +27,6 @@ import {
   bracketMatching,
 } from "@codemirror/language";
 import { defaultKeymap, history, historyKeymap } from "@codemirror/commands";
-import { searchKeymap, highlightSelectionMatches } from "@codemirror/search";
 import {
   autocompletion,
   completionKeymap,
@@ -62,13 +61,10 @@ const customSetup = [
   rectangularSelection(),
   // Show a crosshair cursor when rectangular selecting
   crosshairCursor(),
-  // Highlight matching search results
-  highlightSelectionMatches(),
   // Key bindings
   keymap.of([
     ...closeBracketsKeymap,
     ...defaultKeymap,
-    ...searchKeymap,
     ...historyKeymap,
     ...completionKeymap,
     ...lintKeymap,


### PR DESCRIPTION
**Before**: Line numbers, borders competing for attention
**After**: Clean, borderless editors that put content first

<img width="562" alt="Clean borderless CodeMirror editors" src="https://github.com/user-attachments/assets/98423db6-4c4e-4dc6-aa70-ccc36d1f767e" />

### Editor Experience

- **Removed line numbers and gutters** - Unnecessary visual noise in notebook cells
- **Eliminated all borders** - Seamless integration with notebook flow
- **Preserved all functionality** - Syntax highlighting, autocomplete, bracket matching, etc.