### PR TITLE
Add documentation about technologies used

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ collaborative notebook system with AI integration.
 - **[AI Context Visibility](./ai-context-visibility.md)** - Context control
   implementation
 - **[Testing](./TESTING.md)** - Testing strategy and current gaps
+- **[Technologies](./technologies/README.md)** - Introduction to the various technologies used
 
 ### 📋 Proposals
 

--- a/docs/technologies/README.md
+++ b/docs/technologies/README.md
@@ -3,3 +3,4 @@ The anode ecosystem uses several modern technologies together, in order to drive
 # Table Of Contents
 
 - [Deno: A typescript runtime, similar to node](./deno.md)
+- [Pyodide: Running python code in a javascript runtime](./pyodide.md)

--- a/docs/technologies/README.md
+++ b/docs/technologies/README.md
@@ -4,3 +4,4 @@ The anode ecosystem uses several modern technologies together, in order to drive
 
 - [Deno: A typescript runtime, similar to node](./deno.md)
 - [Pyodide: Running python code in a javascript runtime](./pyodide.md)
+- [Livestore: multi-client state management](./livestore.md)

--- a/docs/technologies/README.md
+++ b/docs/technologies/README.md
@@ -1,0 +1,5 @@
+The anode ecosystem uses several modern technologies together, in order to drive this experience. Some or all of these technologies might be unfamiliar to developers, so this section is meant to provide an overview as to what these technologies are, and how they're specifically used in the codebase.
+
+# Table Of Contents
+
+- [Deno: A typescript runtime, similar to node](./deno.md)

--- a/docs/technologies/deno.md
+++ b/docs/technologies/deno.md
@@ -1,0 +1,37 @@
+# Deno introduction
+
+Deno is an alternative to node.js. It is a command line tool that can install packages, and execute typescript or wasm. It additionally has built-in dev tooling around linting, formatting, and testing, removing the need for configuring these manually.
+
+# Do I need to install deno to run anode?
+
+Not directly. This anode repository is a traditional node-based application. It uses traditional nodejs paradigms (the only difference is using pnpm instead of npm for managing packages).
+
+However, once you launch anode, you'll need to connect it to a runtime agent to execute python code. For example, the given command of `NOTEBOOK_ID=notebook-abc-123 deno run --allow-all --env-file=.env "jsr:@runt/pyodide-runtime-agent"` uses deno for this part of the application. For local development, you'll probably run the runtime agent with deno on the same machine, otherwise it could be run on a completely different computer.
+
+Deno is chosen for the runtime agent because it offers better WASM support for async networking and other native features, which are required for our pyodide runtime.
+
+# What kinds of files can you run with deno?
+
+Deno supports subsets of web standards (think import package), promises, async/await. So, if your package is regular typescript, this will probably work out-of-the box.
+
+However, deno won't run Node code out of the box. If you're writing a deno-native package, this means making a series of source code transformations. So, instead of `import { promises as fs } from 'fs';`, you need to change the code to use the node shim layer of deno, which would be `import * as fs from 'node:fs/promises';`
+
+Similarly, npm packages require a prefix. Instead of `import React from 'react'`, you would use `import React from 'npm:react'`. All imports in Deno are URLs (unless aliased), following the JavaScript import specification. You can also alias or map these specifiers in the import map found in deno.json, allowing you to customize or simplify import paths as needed.
+
+# Permission model
+
+When you start the deno runtime, you need to specify on the command line what types of permissions the app should be allowed to have (defaults to none). For example `deno --allow-net` would give the program the ability to bind network sockets. You should give the [security docs](https://docs.deno.com/runtime/fundamentals/security/) a read to understand how this works.
+
+# NPM, JSR, and Deno Land
+
+These are all package repositories. JSR is a superset of npm - it contains packages that work for the node runtime, as well as deno, cloudflare workers etc. JSR itself will be responsible for transpiling any typescript-only package to work for javascript-only runtimes (node).
+
+The difference between deno.land and jsr is that deno.land is a caching service behind some 3rd party URL. For example, you can publish a package to github, and have it cached on deno. Since deno.land doesn't maintain ownership, this means if the underlying host changes, then deno.land will change as well.
+
+Another interesting thing that comes from deno understanding typescript is that we don't _need_ to bundle the imports. We can just `import React from https://esm.sh/react` (using the built in ecmascript standards) to pull the package remotely.
+
+# Where do I learn more?
+
+- [What is Deno](https://docs.deno.com/examples/what_is_deno/)
+- [Video Tutorial series](https://www.youtube.com/watch?v=KPTOo4k8-GE&list=PLvvLnBDNuTEov9EBIp3MMfHlBxaKGRWTe&index=1)
+- [Runt codebase](https://github.com/runtimed/runt)

--- a/docs/technologies/livestore.md
+++ b/docs/technologies/livestore.md
@@ -1,0 +1,29 @@
+# Livestore Introduction
+
+Livestore is a javascript library which is designed for frontends to emit events into an event log. These events are then reduced (or materialized) into a local sqlite database, where there are bindings to let the UI to know when and how to re-draw. So far, this should sound somewhat like redux or zustand. However, keeping the whole event log as the source of truth is important for Livestore, because it additionally enables syncing and conflict resolution of events across multiple clients. Livestore additionally provides a sync handler to take all of these events from multiple clients to produce a single, merged source of truth for events.
+
+# Event sourcing
+
+A livestore event is [schema-based](https://docs.livestore.dev/reference/state/sqlite-schema/), describing what events can be triggered and the payload they need to have. You can see the current schema for anode [here](https://github.com/runtimed/runt/blob/main/packages/schema/mod.ts)
+
+This is made simple by LiveStore's react bindings, so the code looks like `const { store } = useStore();` and then `store.commit(event)`. These events are then run through any `materializers` hooks on the store side to compute derived state (so far we haven't needed this). Finally, there's a `useQuery` selector to get the data out of the database, notify the component when things change, and then render the state
+
+# Syncing
+
+You can use a github metaphor for thinking about how this works with multiple clients. Imagine that every event is a commit. When you want to update your changes to the central document store, the code will:
+
+1. Do a git pull to grab all of the latest changes
+2. Rebase the local event log on top of the latest changes
+3. Do a git push to send the new events
+
+So there's a few things that can happen here. What happens if the rebase operation produces merge conflicts? That's a great question and it hasn't [been implemented yet](https://docs.livestore.dev/reference/syncing/#merge-conflicts)
+Then, what happens if someone else does a git push in between steps 2 and 3? In this case the document server will reject the slower client, and that client will have to repeat the operations all over again.
+
+This has the downside that although the system as a whole makes progress (since some push always wins), there's no guarantee a particular client will make progress
+
+# More info
+
+- [React getting started](https://docs.livestore.dev/getting-started/expo/)
+- [Livestore vs redux](https://docs.livestore.dev/evaluation/technology-comparison/#livestore-vs-redux)
+- [Thinking about event logs](https://engineering.linkedin.com/distributed-systems/log-what-every-software-engineer-should-know-about-real-time-datas-unifying)
+- [Syncing diagrams](https://docs.livestore.dev/reference/syncing/#advanced)

--- a/docs/technologies/pyodide.md
+++ b/docs/technologies/pyodide.md
@@ -1,0 +1,44 @@
+# Pyodide Introduction
+
+Pyodide allows you to run python code in a javascript runtime environment. To understand exactly how that works, let's quickly review how the CPython program works under normal circumstances. CPython is written in C as its source code. The code is then compiled into assembly (x86-64 or arm64), additionally targeting your operating system (linux, mac, etc), and that produces the final `python` binary. When you run `python script.py`, these assembly instructions know how to parse and execute script.py, providing a runtime that implements things like `os.open` and other API's
+
+Now let's look at what happens for pyodide. We start with the same C source code in CPython. However, instead of targeting a specific assembly & operating system, pyodide targets web assembly as the compilation target. This resulting binary can't execute on its own, but needs to run from an engine (like your web browser or deno) which can execute web assembly. However, once that happens, then python can once again parse a `script.py` file and execute it.
+
+The net result is that a browser can load up Pyodide, and then parse and handle a .py file in a similar manner as normal Python.
+
+Beyond this simple introduction there's some extra advantages to Pyodide (javascript interaction), and some disadvantages (package availability, system interactions) that we'll cover later
+
+# LLVM, Enscriptem, and WASI
+
+When we say "generate webassembly" that's hiding a lot of complexity under the covers. If you're interested in reading a more detailed description, I would start with a [WASI overview](https://hacks.mozilla.org/2019/03/standardizing-wasi-a-webassembly-system-interface/), and Cloudflare's [python worker post](https://blog.cloudflare.com/python-workers/)
+
+The very beginning of the compilation process is standardized. We start with the C source code, and then use the LLVM ecosystem to begin compilation. LLVM is a system where you have various frontends that understand the source code (like CLang for C), a standardized intermediate format (LLVM IR), and then a backend to produce the target code. If you're already using LLVM to build CPython nomally, then the first part is already done.
+
+Enscriptem is a backend which takes the IR and generates webassembly. In addition, enscriptem created its own libc implementation that diverts some of the system-calling code back to the javascript land to use with browser api's.
+
+This leads to a very non-portable mechanism where the compiled program is directly tied to how the system calls are supposed to work. The WASI implementation was made to standardize this, however that's not what pyodide uses.
+
+# Javascript glue
+
+Python has always had a way to interact with other languages - this is how you can call C code from python for example. Pyodide's implementation also generates modules that interact with the browser, which is then made available to python code using the [FFI](https://pyodide.org/en/stable/usage/api/python-api/ffi.html#module-pyodide.ffi). This bridge works in both directions, so you can use python code to interact with javascript and the other way around.
+
+Different environments expose these wrappers a bit differently. For example, in pyscript one uses `from pyscript import window, document`, and in cloudflare workers it's `from js import document` but these are all built on top of what pyodide provides
+
+# Python package availability
+
+Python packages also can contain compiled code. The same challenges apply and they won't work in web assembly without cross-compiling them. That is why pyodide has a specific list of packages it cross compiles. This step is not needed if the package is pure python & available via a wheel file.
+
+# System compatibility
+
+Aside from cross-compiling, the underlying environments are just different. Cloudflare's blog has a lot more details, but for example the async programming model, access to raw sockets, filesystems and more are different in a browser environment as opposed to a raw machine. This is why other packages just aren't available at all, or require [source code changes](https://github.com/cloudflare/pyodide/blob/main/packages/httpx/httpx_patch.py) to adapt a package to working in a browser environment, regardless of the fact that it's in web assembly.
+
+# Browsers, deno, and workers
+
+Pyodide by itself just provides the mechanism to cross-compile python and other packages. It doesn't actually run the code itself. That's where a runtime comes in. For pyscript, this means your browser. For cloudflare it means their worker system. For anode, it means loading pyodide in deno.
+
+# Learn more
+
+- [WASI overview](https://hacks.mozilla.org/2019/03/standardizing-wasi-a-webassembly-system-interface/)
+- [Cloudflare's python worker post](https://blog.cloudflare.com/python-workers/)
+- [Urllib3 and webassembly](https://urllib3.readthedocs.io/en/stable/reference/contrib/emscripten.html)
+- [Pyscript introduction](https://www.anaconda.com/blog/pyscript-python-in-the-browser)


### PR DESCRIPTION
Anode is using some newer technologies (and will probably pick up some other new concepts in the future). This provides a getting started overview, along with some links to go deeper as needed.

This fills an onboarding gap where new developers need to understand both our codebase and what it's relying on