### PR TITLE
toss max height on svg

### DIFF
--- a/src/components/outputs/SvgOutput.tsx
+++ b/src/components/outputs/SvgOutput.tsx
@@ -2,18 +2,13 @@ import React from "react";
 
 interface SvgOutputProps {
   content: string;
-  maxHeight?: string;
 }
 
-export const SvgOutput: React.FC<SvgOutputProps> = ({
-  content,
-  maxHeight = "400px",
-}) => {
+export const SvgOutput: React.FC<SvgOutputProps> = ({ content }) => {
   return (
     <div className="py-2">
       <div
         className="max-w-full overflow-hidden"
-        style={{ maxHeight }}
         dangerouslySetInnerHTML={{ __html: content }}
       />
     </div>


### PR DESCRIPTION
Allow for tall plots, otherwise they get truncated.