### PR TITLE
Fix delete cell focus teleporting to top

### DIFF
--- a/src/components/notebook/NotebookViewer.tsx
+++ b/src/components/notebook/NotebookViewer.tsx
@@ -74,6 +74,7 @@ export const NotebookViewer: React.FC<NotebookViewerProps> = ({
   const [showRuntimeHelper, setShowRuntimeHelper] = React.useState(false);
   const [focusedCellId, setFocusedCellId] = React.useState<string | null>(null);
   const [contextSelectionMode, setContextSelectionMode] = React.useState(false);
+  const hasEverFocusedRef = React.useRef(false);
 
   const currentNotebookId = getCurrentNotebookId();
   const runtimeCommand = getRuntimeCommand(currentNotebookId);
@@ -267,6 +268,7 @@ export const NotebookViewer: React.FC<NotebookViewerProps> = ({
 
   const focusCell = useCallback((cellId: string) => {
     setFocusedCellId(cellId);
+    hasEverFocusedRef.current = true;
   }, []);
 
   const focusNextCell = useCallback(
@@ -310,10 +312,11 @@ export const NotebookViewer: React.FC<NotebookViewerProps> = ({
     }
   }, [focusedCellId, cells]);
 
-  // Focus first cell when notebook loads and has cells
+  // Focus first cell when notebook loads and has cells (but not after deletion)
   React.useEffect(() => {
-    if (!focusedCellId && cells.length > 0) {
+    if (!focusedCellId && cells.length > 0 && !hasEverFocusedRef.current) {
       setFocusedCellId(cells[0].id);
+      hasEverFocusedRef.current = true;
     }
   }, [focusedCellId, cells]);
 

--- a/src/hooks/useCellFocus.ts
+++ b/src/hooks/useCellFocus.ts
@@ -20,6 +20,7 @@ interface UseCellFocusOptions {
 export const useCellFocus = ({ cells, onAddCell }: UseCellFocusOptions) => {
   const [focusedCellId, setFocusedCellId] = useState<string | null>(null);
   const focusTimeoutRef = useRef<number | null>(null);
+  const hasEverFocusedRef = useRef(false);
 
   // Cells are already sorted by database query (orderBy("position", "asc"))
   const sortedCells = cells;
@@ -41,6 +42,9 @@ export const useCellFocus = ({ cells, onAddCell }: UseCellFocusOptions) => {
 
     focusTimeoutRef.current = window.setTimeout(() => {
       setFocusedCellId(cellId);
+      if (cellId) {
+        hasEverFocusedRef.current = true;
+      }
     }, 10);
   }, []);
 
@@ -90,9 +94,13 @@ export const useCellFocus = ({ cells, onAddCell }: UseCellFocusOptions) => {
     }
   }, [focusedCellId, cellPositionMap]);
 
-  // Focus first cell when notebook loads and has cells
+  // Focus first cell when notebook loads and has cells (but not after deletion)
   useEffect(() => {
-    if (!focusedCellId && sortedCells.length > 0) {
+    if (
+      !focusedCellId &&
+      sortedCells.length > 0 &&
+      !hasEverFocusedRef.current
+    ) {
       debouncedSetFocus(sortedCells[0].id);
     }
   }, [focusedCellId, sortedCells, debouncedSetFocus]);


### PR DESCRIPTION
Fixes #130

When deleting a cell, focus was incorrectly jumping to the first cell due to aggressive auto-focus behavior.

## Changes
- Added  to track focus history in both  and  hook
- Modified auto-focus logic to only focus first cell on initial notebook load
- After cell deletion, focus is cleared and user stays in current viewport position

## Testing
- Create notebook with many cells
- Scroll down and delete a cell
- Focus should clear without jumping to top