### PR TITLE
Add CodeMirror to AI cells

### DIFF
--- a/src/components/notebook/AiCell.tsx
+++ b/src/components/notebook/AiCell.tsx
@@ -682,14 +682,17 @@ export const AiCell: React.FC<AiCellProps> = ({
             {/* Desktop: CodeMirror Editor */}
             <div className="relative hidden min-h-[1.5rem] sm:block">
               <CodeMirrorEditor
+                className="text-base sm:text-sm"
                 language="markdown"
                 placeholder="Ask me anything about your notebook, data, or analysis..."
                 value={localSource}
                 onValueChange={handleSourceChange}
-                onBlur={updateSource}
+                autoFocus={autoFocus}
                 onFocus={handleFocus}
                 keyMap={keyMap}
-                autoFocus={autoFocus}
+                onBlur={updateSource}
+                enableLineWrapping={true}
+                disableAutocompletion={true}
               />
             </div>
           </div>

--- a/src/components/notebook/Editor.tsx
+++ b/src/components/notebook/Editor.tsx
@@ -136,6 +136,8 @@ function languageFromCellType(
     return "python";
   } else if (cellType === "markdown") {
     return "markdown";
+  } else if (cellType === "ai") {
+    return "markdown";
   }
   return undefined;
 }
@@ -147,6 +149,8 @@ function placeholderFromCellType(
     return "Enter your code here...";
   } else if (cellType === "markdown") {
     return "Enter markdown...";
+  } else if (cellType === "ai") {
+    return "Ask me anything about your notebook, data, or analysis...";
   }
   return "Enter raw text...";
 }

--- a/src/components/notebook/codemirror/CodeMirrorEditor.tsx
+++ b/src/components/notebook/codemirror/CodeMirrorEditor.tsx
@@ -3,6 +3,7 @@ import {
   KeyBinding,
   keymap,
   placeholder as placeholderExt,
+  EditorView,
 } from "@codemirror/view";
 import { useCallback, useEffect, useMemo, useRef } from "react";
 
@@ -11,7 +12,7 @@ import { markdown } from "@codemirror/lang-markdown";
 import { SupportedLanguage } from "@/types/misc.js";
 import { sql } from "@codemirror/lang-sql";
 import { useCodeMirror } from "@uiw/react-codemirror";
-import { baseExtensions } from "./baseExtensions.js";
+import { baseExtensions, aiBaseExtensions } from "./baseExtensions.js";
 
 type CodeMirrorEditorProps = {
   value: string;
@@ -24,6 +25,8 @@ type CodeMirrorEditorProps = {
   keyMap?: KeyBinding[];
   className?: string;
   maxHeight?: string;
+  enableLineWrapping?: boolean;
+  disableAutocompletion?: boolean;
 };
 
 function languageExtension(language: SupportedLanguage) {
@@ -48,20 +51,40 @@ export const CodeMirrorEditor: React.FC<CodeMirrorEditorProps> = ({
   onBlur,
   placeholder,
   maxHeight,
+  enableLineWrapping = false,
+  disableAutocompletion = false,
 }) => {
   const editorRef = useRef<HTMLDivElement | null>(null);
 
   const langExtension = useMemo(() => languageExtension(language), [language]);
 
   const extensions = useMemo(() => {
-    const exts = [keymap.of(keyMap || []), ...baseExtensions, langExtension];
+    const selectedBaseExtensions = disableAutocompletion
+      ? aiBaseExtensions
+      : baseExtensions;
+
+    const exts = [
+      keymap.of(keyMap || []),
+      ...selectedBaseExtensions,
+      langExtension,
+    ];
 
     if (placeholder) {
       exts.push(placeholderExt(placeholder));
     }
 
+    if (enableLineWrapping) {
+      exts.push(EditorView.lineWrapping);
+    }
+
     return exts;
-  }, [keyMap, langExtension, placeholder]);
+  }, [
+    keyMap,
+    langExtension,
+    placeholder,
+    enableLineWrapping,
+    disableAutocompletion,
+  ]);
 
   const handleChange = useCallback(
     (val: string) => {

--- a/src/components/notebook/codemirror/baseExtensions.ts
+++ b/src/components/notebook/codemirror/baseExtensions.ts
@@ -52,4 +52,27 @@ export const basicSetup: Extension = (() => [
   customStyles,
 ])();
 
+export const aiBasicSetup: Extension = (() => [
+  history(),
+  drawSelection(),
+  dropCursor(),
+  EditorState.allowMultipleSelections.of(true),
+  indentOnInput(),
+  syntaxHighlighting(defaultHighlightStyle, { fallback: true }),
+  bracketMatching(),
+  closeBrackets(),
+  // Note: autocompletion() is excluded for AI cells
+  rectangularSelection(),
+  crosshairCursor(),
+  keymap.of([
+    ...closeBracketsKeymap,
+    ...defaultKeymap,
+    ...historyKeymap,
+    // Note: completionKeymap is excluded for AI cells
+    ...lintKeymap,
+  ]),
+  customStyles,
+])();
+
 export const baseExtensions = [basicSetup, githubLight];
+export const aiBaseExtensions = [aiBasicSetup, githubLight];


### PR DESCRIPTION
Use CodeMirror with markdown highlighting and word wrapping for AI cells on desktop. Wanted this so I can write novels to the agent before it goes to town on my data.