### PR TITLE
provide example .dev.vars

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -1,0 +1,5 @@
+# This is an example file for local Worker development.
+# Copy this file to .dev.vars and fill in the values.
+# This file SHOULD NOT contain real production secrets.
+
+AUTH_TOKEN="insecure-token-change-me"


### PR DESCRIPTION
This allows us to keep a clean `wrangler.toml` for deployment while `.dev.vars` fills out the local variables for dev runs.