### PR TITLE
Update @runt/schema to commit 14c2c60

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@radix-ui/react-separator": "^1.1.7",
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-tooltip": "^1.1.6",
-    "@runt/schema": "github:runtimed/runt#9d5449bdc2133079f6fd5097d7c3549e412ce5dd&path:/packages/schema",
+    "@runt/schema": "github:runtimed/runt#14c2c60f5576eebc509ed76b5cde0c3cab4246a4&path:/packages/schema",
     "@tanstack/react-virtual": "^3.13.12",
     "@types/react-syntax-highlighter": "^15.5.13",
     "@uiw/codemirror-theme-github": "^4.23.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,8 +86,8 @@ importers:
         specifier: ^1.1.6
         version: 1.2.7(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@runt/schema':
-        specifier: github:runtimed/runt#9d5449bdc2133079f6fd5097d7c3549e412ce5dd&path:/packages/schema
-        version: https://codeload.github.com/runtimed/runt/tar.gz/9d5449bdc2133079f6fd5097d7c3549e412ce5dd#path:/packages/schema(acef09458561487e0833c9131402e6fe)
+        specifier: github:runtimed/runt#14c2c60f5576eebc509ed76b5cde0c3cab4246a4&path:/packages/schema
+        version: https://codeload.github.com/runtimed/runt/tar.gz/14c2c60f5576eebc509ed76b5cde0c3cab4246a4#path:/packages/schema(acef09458561487e0833c9131402e6fe)
       '@tanstack/react-virtual':
         specifier: ^3.13.12
         version: 3.13.12(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -1744,8 +1744,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@runt/schema@https://codeload.github.com/runtimed/runt/tar.gz/9d5449bdc2133079f6fd5097d7c3549e412ce5dd#path:/packages/schema':
-    resolution: {path: /packages/schema, tarball: https://codeload.github.com/runtimed/runt/tar.gz/9d5449bdc2133079f6fd5097d7c3549e412ce5dd}
+  '@runt/schema@https://codeload.github.com/runtimed/runt/tar.gz/14c2c60f5576eebc509ed76b5cde0c3cab4246a4#path:/packages/schema':
+    resolution: {path: /packages/schema, tarball: https://codeload.github.com/runtimed/runt/tar.gz/14c2c60f5576eebc509ed76b5cde0c3cab4246a4}
     version: 0.6.0
 
   '@standard-schema/spec@1.0.0':
@@ -5440,7 +5440,7 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.44.2':
     optional: true
 
-  '@runt/schema@https://codeload.github.com/runtimed/runt/tar.gz/9d5449bdc2133079f6fd5097d7c3549e412ce5dd#path:/packages/schema(acef09458561487e0833c9131402e6fe)':
+  '@runt/schema@https://codeload.github.com/runtimed/runt/tar.gz/14c2c60f5576eebc509ed76b5cde0c3cab4246a4#path:/packages/schema(acef09458561487e0833c9131402e6fe)':
     dependencies:
       '@livestore/livestore': 0.3.1(acef09458561487e0833c9131402e6fe)
     transitivePeerDependencies:


### PR DESCRIPTION
Updates the @runt/schema dependency to use commit 14c2c60f5576eebc509ed76b5cde0c3cab4246a4 from the runt repository.