### PR TITLE
Upgrade @runt/schema to 0.6.2

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,4 +25,4 @@ VITE_GOOGLE_CLIENT_ID=94663405566-1go7jlpd2ar9u9urbfirmtjv1bm0tcis.apps.googleus
 VITE_GOOGLE_AUTH_ENABLED="false"
 
 # The command displayed in the UI for starting a local Python runtime.
-VITE_RUNTIME_COMMAND="deno run --unstable-broadcast-channel --allow-all --env-file=./.env jsr:@runt/pyodide-runtime-agent@0.6.0"
+VITE_RUNTIME_COMMAND="deno run --unstable-broadcast-channel --allow-all --env-file=./.env jsr:@runt/pyodide-runtime-agent@0.6.2"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,7 +123,7 @@ The `@runt/schema` package provides the shared types and events between Anode an
 ### Production (JSR Package)
 
 ```json
-"@runt/schema": "jsr:^0.6.0"
+"@runt/schema": "jsr:^0.6.2"
 ```
 
 Use this for stable releases and production deployments.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,7 +85,7 @@ The `@runt/schema` package provides shared types and events between Anode and Ru
 ### Production (JSR Package)
 
 ```json
-"@runt/schema": "jsr:^0.6.0"
+"@runt/schema": "jsr:^0.6.2"
 ```
 
 Use this for stable releases and production deployments.

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ The `@runt/schema` package provides shared types and events between Anode and Ru
 **Production (JSR Package)**:
 
 ```json
-"@runt/schema": "jsr:^0.6.0"
+"@runt/schema": "jsr:^0.6.2"
 ```
 
 **Testing PR Changes (GitHub Reference)**:

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "dev:scan": "pnpm run dev & npx react-scan@latest localhost:5173",
     "dev:prod": "vite --mode production",
     "dev:sync": "wrangler dev",
-    "dev:runtime": "deno run --allow-all --env-file=.env \"jsr:@runt/pyodide-runtime-agent@^0.6.0\"",
+    "dev:runtime": "deno run --allow-all --env-file=.env \"jsr:@runt/pyodide-runtime-agent@^0.6.2\"",
     "build": "vite build --mode development",
     "build:preview": "vite build --mode preview",
     "build:production": "vite build --mode production",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@radix-ui/react-separator": "^1.1.7",
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-tooltip": "^1.1.6",
-    "@runt/schema": "github:runtimed/runt#8d3bd82a1c2e54cf46b0f133d327d4ca6de6acdc&path:/packages/schema",
+    "@runt/schema": "jsr:^0.6.2",
     "@tanstack/react-virtual": "^3.13.12",
     "@types/react-syntax-highlighter": "^15.5.13",
     "@uiw/codemirror-theme-github": "^4.23.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,8 +86,8 @@ importers:
         specifier: ^1.1.6
         version: 1.2.7(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@runt/schema':
-        specifier: github:runtimed/runt#8d3bd82a1c2e54cf46b0f133d327d4ca6de6acdc&path:/packages/schema
-        version: https://codeload.github.com/runtimed/runt/tar.gz/8d3bd82a1c2e54cf46b0f133d327d4ca6de6acdc#path:/packages/schema(acef09458561487e0833c9131402e6fe)
+        specifier: jsr:^0.6.2
+        version: '@jsr/runt__schema@0.6.2(acef09458561487e0833c9131402e6fe)'
       '@tanstack/react-virtual':
         specifier: ^3.13.12
         version: 3.13.12(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -1080,6 +1080,9 @@ packages:
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
+  '@jsr/runt__schema@0.6.2':
+    resolution: {integrity: sha512-IDMKlP1CbcZyp6i+aGLOJX1425d5vcUgl6VUkyQ0NUFbQDQxXZ3BEzE36GmPXfKzcXww0ya98vlcOUbDu0xm0g==, tarball: https://npm.jsr.io/~/11/@jsr/runt__schema/0.6.2.tgz}
+
   '@lezer/common@1.2.3':
     resolution: {integrity: sha512-w7ojc8ejBqr2REPsWxJjrMFsA/ysDCFICn8zEOR9mrqzOu2amhITYuLD8ag6XZf0CFXDrhKqw7+tW8cX66NaDA==}
 
@@ -1743,10 +1746,6 @@ packages:
     resolution: {integrity: sha512-3+QZROYfJ25PDcxFF66UEk8jGWigHJeecZILvkPkyQN7oc5BvFo4YEXFkOs154j3FTMp9mn9Ky8RCOwastduEA==}
     cpu: [x64]
     os: [win32]
-
-  '@runt/schema@https://codeload.github.com/runtimed/runt/tar.gz/8d3bd82a1c2e54cf46b0f133d327d4ca6de6acdc#path:/packages/schema':
-    resolution: {path: /packages/schema, tarball: https://codeload.github.com/runtimed/runt/tar.gz/8d3bd82a1c2e54cf46b0f133d327d4ca6de6acdc}
-    version: 0.6.0
 
   '@standard-schema/spec@1.0.0':
     resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
@@ -4623,6 +4622,26 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.4
 
+  '@jsr/runt__schema@0.6.2(acef09458561487e0833c9131402e6fe)':
+    dependencies:
+      '@livestore/livestore': 0.3.1(acef09458561487e0833c9131402e6fe)
+    transitivePeerDependencies:
+      - '@effect/cli'
+      - '@effect/cluster'
+      - '@effect/experimental'
+      - '@effect/opentelemetry'
+      - '@effect/platform'
+      - '@effect/platform-browser'
+      - '@effect/platform-bun'
+      - '@effect/platform-node'
+      - '@effect/printer'
+      - '@effect/printer-ansi'
+      - '@effect/rpc'
+      - '@effect/sql'
+      - '@effect/typeclass'
+      - '@opentelemetry/resources'
+      - effect
+
   '@lezer/common@1.2.3': {}
 
   '@lezer/css@1.3.0':
@@ -5439,26 +5458,6 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.44.2':
     optional: true
-
-  '@runt/schema@https://codeload.github.com/runtimed/runt/tar.gz/8d3bd82a1c2e54cf46b0f133d327d4ca6de6acdc#path:/packages/schema(acef09458561487e0833c9131402e6fe)':
-    dependencies:
-      '@livestore/livestore': 0.3.1(acef09458561487e0833c9131402e6fe)
-    transitivePeerDependencies:
-      - '@effect/cli'
-      - '@effect/cluster'
-      - '@effect/experimental'
-      - '@effect/opentelemetry'
-      - '@effect/platform'
-      - '@effect/platform-browser'
-      - '@effect/platform-bun'
-      - '@effect/platform-node'
-      - '@effect/printer'
-      - '@effect/printer-ansi'
-      - '@effect/rpc'
-      - '@effect/sql'
-      - '@effect/typeclass'
-      - '@opentelemetry/resources'
-      - effect
 
   '@standard-schema/spec@1.0.0': {}
 

--- a/src/util/runtime-command.ts
+++ b/src/util/runtime-command.ts
@@ -11,7 +11,7 @@ export function generateRuntimeCommand(
 ): string {
   const baseRuntimeCommand =
     customCommand ||
-    'deno run --allow-all --env-file=.env "jsr:@runt/pyodide-runtime-agent@^0.6.0"';
+    'deno run --allow-all --env-file=.env "jsr:@runt/pyodide-runtime-agent@^0.6.2"';
 
   return `NOTEBOOK_ID=${notebookId} ${baseRuntimeCommand}`;
 }

--- a/test/runtime-command.test.ts
+++ b/test/runtime-command.test.ts
@@ -10,7 +10,7 @@ describe("Runtime Command Generation", () => {
     const runtimeCommand = generateRuntimeCommand(notebookId);
 
     expect(runtimeCommand).toBe(
-      'NOTEBOOK_ID=test-notebook-123 deno run --allow-all --env-file=.env "jsr:@runt/pyodide-runtime-agent@^0.6.0"'
+      'NOTEBOOK_ID=test-notebook-123 deno run --allow-all --env-file=.env "jsr:@runt/pyodide-runtime-agent@^0.6.2"'
     );
   });
 
@@ -51,7 +51,7 @@ describe("Runtime Command Generation", () => {
     const runtimeCommand = generateRuntimeCommand(notebookId);
 
     expect(runtimeCommand).toBe(
-      'NOTEBOOK_ID=notebook-with-dashes_and_underscores.123 deno run --allow-all --env-file=.env "jsr:@runt/pyodide-runtime-agent@^0.6.0"'
+      'NOTEBOOK_ID=notebook-with-dashes_and_underscores.123 deno run --allow-all --env-file=.env "jsr:@runt/pyodide-runtime-agent@^0.6.2"'
     );
   });
 

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -37,7 +37,7 @@ DEPLOYMENT_ENV = "development"
 VITE_LIVESTORE_SYNC_URL = "ws://localhost:8787/livestore"
 VITE_GOOGLE_CLIENT_ID = "94663405566-1go7jlpd2ar9u9urbfirmtjv1bm0tcis.apps.googleusercontent.com"
 VITE_GOOGLE_AUTH_ENABLED = "false"
-VITE_RUNTIME_COMMAND = "deno run --unstable-broadcast-channel --allow-all --env-file=./.env jsr:@runt/pyodide-runtime-agent@0.6.0"
+VITE_RUNTIME_COMMAND = "deno run --unstable-broadcast-channel --allow-all --env-file=./.env jsr:@runt/pyodide-runtime-agent@0.6.2"
 
 
 # ---
@@ -94,7 +94,7 @@ ARTIFACT_THRESHOLD = "16384"
 VITE_LIVESTORE_SYNC_URL = "wss://app.runt.run/livestore"
 VITE_GOOGLE_CLIENT_ID = "94663405566-1go7jlpd2ar9u9urbfirmtjv1bm0tcis.apps.googleusercontent.com"
 VITE_GOOGLE_AUTH_ENABLED = "true"
-VITE_RUNTIME_COMMAND = "deno run --unstable-broadcast-channel --allow-all --env-file=./.env.production jsr:@runt/pyodide-runtime-agent@0.6.0"
+VITE_RUNTIME_COMMAND = "deno run --unstable-broadcast-channel --allow-all --env-file=./.env.production jsr:@runt/pyodide-runtime-agent@0.6.2"
 
 
 # Preview Environment (all-in-one worker)
@@ -128,7 +128,7 @@ ARTIFACT_THRESHOLD = "16384"
 VITE_LIVESTORE_SYNC_URL = "wss://preview.runt.run/livestore"
 VITE_GOOGLE_CLIENT_ID = "94663405566-1go7jlpd2ar9u9urbfirmtjv1bm0tcis.apps.googleusercontent.com"
 VITE_GOOGLE_AUTH_ENABLED = "true"
-VITE_RUNTIME_COMMAND = "deno run --unstable-broadcast-channel --allow-all --env-file=./.env.preview jsr:@runt/pyodide-runtime-agent@0.6.0"
+VITE_RUNTIME_COMMAND = "deno run --unstable-broadcast-channel --allow-all --env-file=./.env.preview jsr:@runt/pyodide-runtime-agent@0.6.2"
 
 
 # ---


### PR DESCRIPTION
Upgrades schema dependency from GitHub reference to JSR package version 0.6.2. Updates runtime command versions across all environments and documentation. All tests passing.