### PR TITLE
Update documentation to accurately reflect the current artifact service implementation status.

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ event-sourcing based local-first data synchronization library.
   materializers) - Published JSR package imported by all packages with full type
   inference. Comes via https://github.com/runtimed/runt's deno monorepo
 - **Web Client** (`@anode/web-client`): React-based web interface
-- **Document Worker** (`@anode/docworker`): Cloudflare Worker for sync backend
+- **Document Worker** (`@anode/docworker`): Cloudflare Worker for sync backend with artifact storage
 - **Pyodide Runtime Agent** (`@anode/pyodide-runtime-agent`): Python execution
   client
 
@@ -68,6 +68,7 @@ event-sourcing based local-first data synchronization library.
 - ✅ **Terminal output grouping** - Consecutive terminal outputs merge naturally
 - ✅ **Error output rendering** - Proper traceback display with JSON error parsing
 - ✅ **All tests passing** - 58/58 tests covering output system
+- 🚧 **Artifact service** - First version deployed with basic upload/download endpoints (has known security limitations)
 
 ### Core Architecture Constraints
 
@@ -80,6 +81,7 @@ event-sourcing based local-first data synchronization library.
 - **Session-based runtimes**: Each runtime restart gets unique `sessionId`
 - **One runtime per notebook**: Each notebook has exactly one active runtime at a
   time
+- **Artifact storage**: First version backend for external storage (uploads authenticated, downloads currently unauthenticated)
 
 ### Runtime-Notebook Relationship
 
@@ -259,6 +261,12 @@ anode/
 ├── public/
 ├── src/
 │   ├── auth/
+│   ├── backend/
+│   │   ├── artifact.ts
+│   │   ├── auth.ts
+│   │   ├── entry.ts
+│   │   ├── sync.ts
+│   │   └── types.ts
 │   ├── components/
 │   │   ├── auth/
 │   │   ├── notebook/
@@ -304,10 +312,9 @@ anode/
 
 **Deployment (Cloudflare):**
 
-- Pages: `https://anode.pages.dev` (from `/dist`)
-- Workers: `https://anode-docworker.rgbkrk.workers.dev` (from
-  `/src/sync/sync.ts`)
+- All-in-one Worker: `https://app.runt.run` (unified worker serving both backend and frontend)
 - D1: Production data persistence
+- R2: Artifact storage for large outputs
 - Secrets: Auth tokens, API keys
 - Runtime: Python execution via `@runt` packages
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,101 +1,107 @@
 # Deployment Guide
 
-This document describes how to deploy Anode using the split architecture with
-Cloudflare Pages for the web client and Cloudflare Workers for the sync backend.
+This document describes how to deploy Anode using the unified all-in-one worker
+architecture that serves both the web client and backend API from a single
+Cloudflare Worker.
 
 ## Architecture Overview
 
-- **Cloudflare Pages**: Serves the web client (React app)
-- **Cloudflare Workers**: Handles LiveStore sync backend with Durable Objects
-  and D1
+- **All-in-one Worker**: Single worker serving both frontend assets and backend API
+- **D1 Database**: Persistent storage for LiveStore events
+- **R2 Bucket**: Artifact storage for large outputs (images, files, data)
+- **Durable Objects**: WebSocket server for real-time sync
 
-This separation is necessary because Cloudflare Workers don't support WebSocket
-client connections from Web Workers, which LiveStore requires.
+The unified architecture simplifies deployment while providing artifact storage
+for large notebook outputs that exceed the event size threshold.
 
 ## Prerequisites
 
-- Cloudflare account with Pages and Workers access
+- Cloudflare account with Workers, D1, and R2 access
 - D1 database created for production
+- R2 bucket created for artifact storage
 - Wrangler CLI installed and authenticated
 
 ## Quick Start
 
-Deploy both services with one command:
+Deploy the all-in-one worker with one command:
 
 ```bash
-pnpm deploy  # Deploys both web client and worker
+pnpm deploy  # Builds and deploys unified worker
 ```
 
 This will:
 
 1. Build the web client for production
-2. Deploy both the sync worker and web client to Cloudflare
+2. Deploy the unified worker serving both frontend and backend
+3. Configure D1 database and R2 bucket bindings
 
 ## Deployment Steps
 
-### Option 1: Deploy Both Services (Recommended)
+### Option 1: Deploy Unified Worker (Recommended)
 
-Deploy both the sync backend and web client with a single command:
+Deploy the all-in-one worker with a single command:
 
 ```bash
-# Deploy both services
+# Deploy unified worker
 pnpm deploy
 ```
 
-This builds the web client and deploys both services to Cloudflare.
+This builds the web client and deploys the unified worker to Cloudflare.
 
-### Option 2: Deploy Services Individually
+### Option 2: Deploy to Specific Environment
 
-**Deploy the Sync Backend (Worker):**
-
-```bash
-pnpm deploy:worker
-```
-
-**Deploy the Web Client (Pages):**
-
-```bash
-pnpm deploy:web
-```
-
-### Option 3: Manual Deployment
-
-**1. Deploy the Sync Backend (Worker)**
-
-The sync backend runs on Cloudflare Workers and handles LiveStore
-synchronization.
+**Deploy to Production:**
 
 ```bash
 wrangler deploy --env production
 ```
 
-This deploys to: `https://anode-docworker.rgbkrk.workers.dev`
+**Deploy to Preview:**
+
+```bash
+wrangler deploy --env preview
+```
+
+### Option 3: Manual Deployment
+
+**1. Build the Web Client**
+
+```bash
+pnpm build
+```
+
+**2. Deploy the Unified Worker**
+
+The unified worker serves both the web client and backend API, including
+artifact storage endpoints.
+
+```bash
+wrangler deploy --env production
+```
+
+This deploys to: `https://app.runt.run` (production) or your configured domain.
 
 **Required secrets:**
 
 ```bash
 echo "your-secure-token" | pnpm wrangler secret put AUTH_TOKEN --env production
-```
-
-**2. Deploy the Web Client (Pages)**
-
-The web client is served from Cloudflare Pages with static assets.
-
-```bash
-pnpm build && wrangler pages deploy dist --project-name anode
+echo "your-google-client-secret" | pnpm wrangler secret put GOOGLE_CLIENT_SECRET --env production
 ```
 
 ## Environment Variables
 
-### Worker Environment Variables
+### Unified Worker Environment Variables
 
 Set in `wrangler.toml`:
 
 - `DEPLOYMENT_ENV`: `"production"`
 - `GOOGLE_CLIENT_ID`: Your Google OAuth client ID
+- `ARTIFACT_STORAGE`: `"r2"`
+- `ARTIFACT_THRESHOLD`: `"16384"` (16KB threshold for artifact storage)
 - `AUTH_TOKEN`: Set via secrets (see above)
+- `GOOGLE_CLIENT_SECRET`: Set via secrets (see above)
 
-### Web Client Environment Variables
+### Web Client Build Variables
 
 Web client environment variables are built into the static assets at build time:
 
@@ -165,30 +171,84 @@ jobs:
       - name: Run tests
         run: pnpm test --run
 
-      - name: Deploy worker
-        run: pnpm deploy:worker
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      - name: Build web client
+        run: pnpm build
 
-      - name: Deploy web client
-        run: pnpm deploy:web
+      - name: Deploy unified worker
+        run: wrangler deploy --env production
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
 ```
 
-### Cloudflare Pages Git Integration
+### Manual Wrangler Commands
 
-Alternatively, you can connect the repository directly to Cloudflare Pages:
+For manual deployment to different environments:
 
-1. Go to Cloudflare Pages dashboard
-2. Connect to Git repository
-3. Set build settings:
-   - **Build command**: `pnpm build:prod`
-   - **Build output directory**: `dist`
-   - **Root directory**: Leave empty
-4. Environment variables are configured in `wrangler.toml`
+```bash
+# Deploy to production
+wrangler deploy --env production
+
+# Deploy to preview
+wrangler deploy --env preview
+
+# Deploy with local development (no environment)
+wrangler deploy
+```
+
+## Infrastructure Setup
+
+### Create D1 Database
+
+```bash
+# Create production database
+pnpm wrangler d1 create anode-main-prod-db
+
+# Create preview database
+pnpm wrangler d1 create anode-docworker-preview-db
+```
+
+Update `wrangler.toml` with the returned database IDs.
+
+### Create R2 Bucket
+
+```bash
+# Create production artifact bucket
+pnpm wrangler r2 bucket create anode-artifacts-prod
+
+# Create preview artifact bucket
+pnpm wrangler r2 bucket create anode-artifacts-preview
+```
+
+### Set Required Secrets
+
+```bash
+# Production secrets
+echo "your-secure-token" | pnpm wrangler secret put AUTH_TOKEN --env production
+echo "your-google-client-secret" | pnpm wrangler secret put GOOGLE_CLIENT_SECRET --env production
+
+# Preview secrets
+echo "your-preview-token" | pnpm wrangler secret put AUTH_TOKEN --env preview
+echo "your-google-client-secret" | pnpm wrangler secret put GOOGLE_CLIENT_SECRET --env preview
+```
 
 ## Troubleshooting
+
+### Deployment Issues
+
+| Problem | Solution |
+|---------|----------|
+| Missing database ID | Create D1 database and update `wrangler.toml` |
+| Missing R2 bucket | Create R2 bucket and update `wrangler.toml` |
+| Authentication errors | Set required secrets with `wrangler secret put` |
+| Build failures | Run `pnpm build` locally to check for errors |
+
+### Artifact Storage Issues
+
+| Problem | Solution |
+|---------|----------|
+| Large outputs not storing | Check R2 bucket configuration and ARTIFACT_THRESHOLD |
+| Artifact fetch failures | Verify R2 bucket permissions and CORS settings |
+| Upload authentication | Ensure AUTH_TOKEN is set correctly |
 
 ### WebSocket Connection Issues
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,15 +15,17 @@ collaborative notebook system with AI integration.
 
 - **[AI Context Controls](./proposals/ai-context-controls.md)** - User controls
   for AI context inclusion/exclusion ✅ **Implemented**
-- **[Updateable Outputs](./proposals/updateable-outputs.md)** -
-  Jupyter-compatible display updates and stream merging
+- **[Artifact Service Design](./proposals/artifact-service-design.md)** - 
+  External storage for large outputs 🚧 **First Version (has limitations)**
+- **[Unified Output System](./proposals/unified-output-system.md)** - 
+  Granular, type-safe events for all output types ✅ **Implemented**
 
 ### 🏗️ Architecture Overview
 
 Anode is a simplified single-application notebook system that provides:
 
 - **Web Client**: React-based notebook interface with real-time collaboration
-- **Sync Worker**: Cloudflare Worker handling LiveStore synchronization
+- **Unified Worker**: Cloudflare Worker serving both frontend and backend with artifact storage
 - **Python Runtime**: Handled by separate `@runt` packages for execution and AI
   features
 
@@ -32,7 +34,7 @@ Anode is a simplified single-application notebook system that provides:
 - **LiveStore**: Event-sourcing based local-first data synchronization
 - **React**: Modern web interface with real-time collaborative editing
 - **Vite**: Build system and development server
-- **Cloudflare**: Pages (web client) + Workers (sync backend) deployment
+- **Cloudflare**: Workers (unified backend + frontend) + D1 (database) + R2 (artifact storage)
 
 ### 🚀 Current Status
 
@@ -53,6 +55,7 @@ docs/
 ├── DEPLOYMENT.md                  # Deployment instructions
 ├── proposals/
 │   ├── ai-context-controls.md     # User controls for AI context
+│   ├── artifact-service-design.md # External storage for large outputs
 │   └── unified-output-system.md   # Unified output system proposal
 └── technologies/
     ├── README.md                  # Introduction to technologies

--- a/docs/proposals/artifact-service-design.md
+++ b/docs/proposals/artifact-service-design.md
@@ -1,8 +1,46 @@
 # Artifact Service Design
 
+**Status: 🚧 FIRST VERSION DEPLOYED** - Basic artifact service is operational but has known limitations.
+
 This document describes how runt will store large outputs as external artifacts
 instead of embedding them in LiveStore events. The goal is to keep events small
 while still allowing reasonably fast display of images, files, and tables.
+
+## Implementation Status
+
+**✅ First Version Deployed:**
+- POST /api/artifacts endpoint for uploading large outputs (with auth token authentication)
+- GET /api/artifacts/{id} content routes for serving artifacts (currently unauthenticated)
+- R2 and local storage backends with environment-aware switching
+- Basic artifact ID generation with notebook scoping
+- Integration with unified worker architecture
+
+**⚠️ Known Limitations (First Version):**
+- Downloads are currently unauthenticated (security concern)
+- No multipart upload support for very large files
+- No validation that users have permission to add artifacts to specific notebooks
+- No validation that users can view specific artifacts
+- Basic UUID-based artifact IDs instead of content addressing
+- No garbage collection for orphaned artifacts
+
+**🚧 Immediate Security & Reliability Fixes:**
+- Authenticated downloads (cookies or signed URLs)
+- User permission validation for notebook artifacts
+- Multipart upload support for large files
+- Proper content addressing with deduplication
+- Garbage collection for orphaned artifacts
+
+**🚧 Runtime Integration (Next Steps):**
+- Runtime agents automatically uploading large outputs to artifact service
+- MediaRepresentationSchema usage in output events (inline vs artifact)
+- Frontend rendering of artifact-based outputs
+- Size threshold enforcement in runtime execution context
+
+**🔮 Future Enhancements:**
+- Streaming upload/download for very large files
+- Pre-signed URLs for R2 optimization
+- Compression for text-based artifacts
+- CDN integration for faster artifact serving
 
 ## Motivation
 
@@ -297,12 +335,14 @@ event log while still making it accessible to other tools.
 
 ## Implementation Priority
 
-1. **Happy path**: POST `/api/artifacts` → storage upload → return `artifactId`
-2. **Content routes**: GET `/api/artifacts/{id}` → serve content directly
-3. **Runtime integration**: Update ExecutionContext to use artifact threshold
-4. **Auth integration**: Environment-aware serving (cookies vs pre-signed URLs)
-5. **Size threshold**: Configurable via environment variable
-6. **Deduplication**: Content addressing within notebook scope
+1. ✅ **Backend endpoints**: POST `/api/artifacts` → storage upload → return `artifactId`
+2. ⚠️ **Content routes**: GET `/api/artifacts/{id}` → serve content directly (unauthenticated)
+3. ⚠️ **Auth integration**: Upload authentication working, download authentication pending
+4. ✅ **Size threshold**: Configurable via environment variable (ARTIFACT_THRESHOLD)
+5. 🚧 **Security fixes**: Authenticated downloads, permission validation, multipart uploads
+6. 🚧 **Runtime integration**: Update ExecutionContext to use artifact threshold
+7. 🚧 **Frontend rendering**: Display artifact-based outputs in notebook interface
+8. 🚧 **Content addressing**: SHA-256 deduplication within notebook scope
 
 ## Error Handling
 


### PR DESCRIPTION
## Changes

- Mark backend endpoints as first version deployed (not fully implemented)
- Update DEPLOYMENT.md for unified worker architecture with R2 storage
- Add artifact service to docs/README.md proposals list as partial implementation
- Document known limitations in artifact-service-design.md

## Current Status

The artifact service backend is deployed and working, but has known limitations:

* Downloads currently unauthenticated (security concern)
* No permission validation for notebook artifacts
* No multipart upload support for large files
* Basic UUID-based IDs instead of content addressing
