### PR TITLE
Fix test type errors and update to JSR package

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@radix-ui/react-separator": "^1.1.7",
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-tooltip": "^1.1.6",
-    "@runt/schema": "github:runtimed/runt#b2f5f1264cd1ddf51c881192aef6791a968f2b8b&path:/packages/schema",
+    "@runt/schema": "jsr:^0.6.3",
     "@tanstack/react-virtual": "^3.13.12",
     "@types/react-syntax-highlighter": "^15.5.13",
     "@uiw/codemirror-theme-github": "^4.23.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,8 +86,8 @@ importers:
         specifier: ^1.1.6
         version: 1.2.7(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@runt/schema':
-        specifier: github:runtimed/runt#b2f5f1264cd1ddf51c881192aef6791a968f2b8b&path:/packages/schema
-        version: https://codeload.github.com/runtimed/runt/tar.gz/b2f5f1264cd1ddf51c881192aef6791a968f2b8b#path:/packages/schema(f9c23af240f2640c0a9abef8711d3cc6)
+        specifier: jsr:^0.6.3
+        version: '@jsr/runt__schema@0.6.3(f9c23af240f2640c0a9abef8711d3cc6)'
       '@tanstack/react-virtual':
         specifier: ^3.13.12
         version: 3.13.12(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -1085,6 +1085,9 @@ packages:
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
+  '@jsr/runt__schema@0.6.3':
+    resolution: {integrity: sha512-RVr3yy/cq7vvS3OcNVe4Ta5aNUtuVUPpNrGViMK+QHWvau+HjhBuj5cgnOdRkkIJge+TZDS2HuVDVkqRhFhRaw==, tarball: https://npm.jsr.io/~/11/@jsr/runt__schema/0.6.3.tgz}
+
   '@lezer/common@1.2.3':
     resolution: {integrity: sha512-w7ojc8ejBqr2REPsWxJjrMFsA/ysDCFICn8zEOR9mrqzOu2amhITYuLD8ag6XZf0CFXDrhKqw7+tW8cX66NaDA==}
 
@@ -1748,10 +1751,6 @@ packages:
     resolution: {integrity: sha512-SRf1cytG7wqcHVLrBc9VtPK4pU5wxiB/lNIkNmW2ApKXIg+RpqwHfsaEK+e7eH4A1BpI6BX/aBWXxZCIrJg3uA==}
     cpu: [x64]
     os: [win32]
-
-  '@runt/schema@https://codeload.github.com/runtimed/runt/tar.gz/b2f5f1264cd1ddf51c881192aef6791a968f2b8b#path:/packages/schema':
-    resolution: {path: /packages/schema, tarball: https://codeload.github.com/runtimed/runt/tar.gz/b2f5f1264cd1ddf51c881192aef6791a968f2b8b}
-    version: 0.6.0
 
   '@standard-schema/spec@1.0.0':
     resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
@@ -4638,6 +4637,26 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.4
 
+  '@jsr/runt__schema@0.6.3(f9c23af240f2640c0a9abef8711d3cc6)':
+    dependencies:
+      '@livestore/livestore': 0.3.1(f9c23af240f2640c0a9abef8711d3cc6)
+    transitivePeerDependencies:
+      - '@effect/cli'
+      - '@effect/cluster'
+      - '@effect/experimental'
+      - '@effect/opentelemetry'
+      - '@effect/platform'
+      - '@effect/platform-browser'
+      - '@effect/platform-bun'
+      - '@effect/platform-node'
+      - '@effect/printer'
+      - '@effect/printer-ansi'
+      - '@effect/rpc'
+      - '@effect/sql'
+      - '@effect/typeclass'
+      - '@opentelemetry/resources'
+      - effect
+
   '@lezer/common@1.2.3': {}
 
   '@lezer/css@1.3.0':
@@ -5454,26 +5473,6 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.45.0':
     optional: true
-
-  '@runt/schema@https://codeload.github.com/runtimed/runt/tar.gz/b2f5f1264cd1ddf51c881192aef6791a968f2b8b#path:/packages/schema(f9c23af240f2640c0a9abef8711d3cc6)':
-    dependencies:
-      '@livestore/livestore': 0.3.1(f9c23af240f2640c0a9abef8711d3cc6)
-    transitivePeerDependencies:
-      - '@effect/cli'
-      - '@effect/cluster'
-      - '@effect/experimental'
-      - '@effect/opentelemetry'
-      - '@effect/platform'
-      - '@effect/platform-browser'
-      - '@effect/platform-bun'
-      - '@effect/platform-node'
-      - '@effect/printer'
-      - '@effect/printer-ansi'
-      - '@effect/rpc'
-      - '@effect/sql'
-      - '@effect/typeclass'
-      - '@opentelemetry/resources'
-      - effect
 
   '@standard-schema/spec@1.0.0': {}
 


### PR DESCRIPTION
- Import isInlineContainer type guard from @runt/schema
- Use proper type checking for MediaContainer union types
- Replace unsafe direct property access with type guard checks
- Add specific type assertion for known test data structure
- Update package.json to use jsr:@runt/schema@^0.6.3
- All 60 tests passing ✅
- No TypeScript errors ✅

Rationale for type assertion:
The test creates a specific data structure (largeData) and verifies it comes back correctly. The type assertion documents the expected structure that we know we put in, making the test more readable and type-safe than using 'as any'.