### PR TITLE
Fix confusing anon initials

### DIFF
--- a/src/hooks/useUserRegistry.ts
+++ b/src/hooks/useUserRegistry.ts
@@ -149,6 +149,9 @@ export const useUserRegistry = () => {
   const getUserInitials = useCallback(
     (userId: string): string => {
       const userInfo = getUserInfo(userId);
+      if (userInfo.isAnonymous) {
+        return generateInitials(userId);
+      }
       return generateInitials(userInfo.name);
     },
     [getUserInfo]


### PR DESCRIPTION
This is just for anon users. If we want to support anon users in prod, we probably want to generate a name for them randomly, derive one using the session ID.

Before (notice AU is used in both cases):
<img width="681" height="232" alt="Screenshot 2025-07-17 at 10 55 02 AM" src="https://github.com/user-attachments/assets/8ace4be7-1872-49a0-91eb-149dda226047" />

After:
<img width="637" height="210" alt="Screenshot 2025-07-17 at 10 54 33 AM" src="https://github.com/user-attachments/assets/38348f0c-261c-4e3d-a7f4-eb25db4bb131" />