### PR TITLE
Fix mobile code editor padding

### DIFF
--- a/src/components/notebook/cell/shared/Editor.tsx
+++ b/src/components/notebook/cell/shared/Editor.tsx
@@ -93,7 +93,7 @@ export function Editor({
             <Dialog.Title className="sr-only">Editor</Dialog.Title>
             <ErrorBoundary FallbackComponent={ErrorFallback}>
               <CodeMirrorEditor
-                className="relative text-base sm:text-sm"
+                className="bg-background relative text-base sm:text-sm"
                 maxHeight="100svh"
                 language={languageFromCellType(cell.cellType)}
                 placeholder={placeholderFromCellType(cell.cellType)}

--- a/src/components/notebook/codemirror/baseExtensions.ts
+++ b/src/components/notebook/codemirror/baseExtensions.ts
@@ -27,6 +27,12 @@ const customStyles = EditorView.theme({
   "&.cm-focused": {
     outline: "none",
   },
+  // Only apply padding at smaller sizes (max-width: 640px, i.e., Tailwind's sm breakpoint)
+  "@media (max-width: 640px)": {
+    ".cm-content": {
+      padding: "0.75rem 0.5rem",
+    },
+  },
   // Reset cursor animation on focus for better visibility
   "&.cm-focused .cm-cursor": {
     animation: "steps(1) cm-blink 1.2s infinite",


### PR DESCRIPTION
Adding to cm styles so horizontal scrolling doesn't get cut off

After:
<img width="506" height="598" alt="Screenshot 2025-07-17 at 11 59 48 AM" src="https://github.com/user-attachments/assets/8eb217b1-49be-402b-8ee9-d76b39bc7405" />
