### PR TITLE
feature/markdown rendering switch

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "react-error-boundary": "^6.0.0",
     "react-markdown": "^10.1.0",
     "react-syntax-highlighter": "^15.6.1",
+    "react-use": "^17.6.0",
     "strip-ansi": "^7.1.0",
     "tailwind-merge": "^3.3.1",
     "tw-animate-css": "^1.3.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -136,6 +136,9 @@ importers:
       react-syntax-highlighter:
         specifier: ^15.6.1
         version: 15.6.1(react@19.0.0)
+      react-use:
+        specifier: ^17.6.0
+        version: 17.6.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       strip-ansi:
         specifier: ^7.1.0
         version: 7.1.0
@@ -1993,6 +1996,9 @@ packages:
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
 
+  '@types/js-cookie@2.2.7':
+    resolution: {integrity: sha512-aLkWa0C0vO5b4Sr798E26QgOkss68Un0bLjs7u9qxzPT5CG+8DuNTffWES58YzJs3hrVAOs1wonycqEBqNJubA==}
+
   '@types/js-cookie@3.0.6':
     resolution: {integrity: sha512-wkw9yd1kEXOPnvEeEV1Go1MmxtBJL0RR79aOTAApecWFVu7w0NNXNqhcWgvw2YgZDYadliXkl14pa3WXw5jlCQ==}
 
@@ -2161,6 +2167,9 @@ packages:
 
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
+
+  '@xobotyi/scrollbar-width@1.9.5':
+    resolution: {integrity: sha512-N8tkAACJx2ww8vFMneJmaAgmjAG1tnVBZJRLRcx061tmsLRZHSEZSLuGWnwPtunsSLvSqXQ2wfp7Mgqg1I+2dQ==}
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -2442,6 +2451,9 @@ packages:
     resolution: {integrity: sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==}
     engines: {node: '>=18'}
 
+  copy-to-clipboard@3.3.3:
+    resolution: {integrity: sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==}
+
   crelt@1.0.6:
     resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
 
@@ -2451,6 +2463,13 @@ packages:
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  css-in-js-utils@3.1.0:
+    resolution: {integrity: sha512-fJAcud6B3rRu+KHYk+Bwf+WFL2MDCJJ1XG9x137tJQ0xYxor7XziQtuGFbWNdqrvF4Tk26O3H73nfVqXt/fW1A==}
+
+  css-tree@1.1.3:
+    resolution: {integrity: sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==}
+    engines: {node: '>=8.0.0'}
 
   css.escape@1.5.1:
     resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
@@ -2580,6 +2599,9 @@ packages:
 
   error-stack-parser-es@1.0.5:
     resolution: {integrity: sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==}
+
+  error-stack-parser@2.1.4:
+    resolution: {integrity: sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==}
 
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
@@ -2718,6 +2740,12 @@ packages:
 
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fast-shallow-equal@1.0.0:
+    resolution: {integrity: sha512-HPtaa38cPgWvaCFmRNhlc6NG7pv6NUHqjPgVAkWGoB9mQMwYB27/K0CvOM5Czy+qpT3e8XJ6Q4aPAnzpNpzNaw==}
+
+  fastest-stable-stringify@2.0.2:
+    resolution: {integrity: sha512-bijHueCGd0LqqNK9b5oCMHc0MluJAx0cwqASgbWMvkO01lCYgIhacVRLcaDz3QnyYIRNJRDwMb41VuT6pHJ91Q==}
 
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
@@ -2903,6 +2931,9 @@ packages:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
 
+  hyphenate-style-name@1.1.0:
+    resolution: {integrity: sha512-WDC/ui2VVRrz3jOVi+XtjqkDjiVjTtFaAGiW37k6b+ohyQ5wYDOGkvCZa8+H0nx3gyvv0+BST9xuOgIyGQ00gw==}
+
   iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
     engines: {node: '>=0.10.0'}
@@ -2936,6 +2967,9 @@ packages:
 
   inline-style-parser@0.2.4:
     resolution: {integrity: sha512-0aO8FkhNZlj/ZIbNi7Lxxr12obT7cL1moPfE4tg1LkX7LlLfC6DeX4l2ZEud1ukP9jNQyNnfzQVqwbwmAATY4Q==}
+
+  inline-style-prefixer@7.0.1:
+    resolution: {integrity: sha512-lhYo5qNTQp3EvSSp3sRvXMbVQTLrvGV6DycRMJ5dm2BLMiJ30wpXKdDdgX+GmJZ5uQMucwRKHamXSst3Sj/Giw==}
 
   ip-address@9.0.5:
     resolution: {integrity: sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==}
@@ -3011,6 +3045,9 @@ packages:
   jiti@2.4.2:
     resolution: {integrity: sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==}
     hasBin: true
+
+  js-cookie@2.2.1:
+    resolution: {integrity: sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==}
 
   js-cookie@3.0.5:
     resolution: {integrity: sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==}
@@ -3204,6 +3241,9 @@ packages:
   mdast-util-to-string@4.0.0:
     resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
 
+  mdn-data@2.0.14:
+    resolution: {integrity: sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==}
+
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
@@ -3346,6 +3386,12 @@ packages:
 
   mute-stream@0.0.8:
     resolution: {integrity: sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==}
+
+  nano-css@5.6.2:
+    resolution: {integrity: sha512-+6bHaC8dSDGALM1HJjOHVXpuastdu2xFoZlC77Jh4cg+33Zcgm+Gxd+1xsnpZK14eyHObSp82+ll5y3SX75liw==}
+    peerDependencies:
+      react: 19.0.0
+      react-dom: 19.0.0
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
@@ -3690,6 +3736,18 @@ packages:
     peerDependencies:
       react: 19.0.0
 
+  react-universal-interface@0.6.2:
+    resolution: {integrity: sha512-dg8yXdcQmvgR13RIlZbTRQOoUrDciFVoSBZILwjE2LFISxZZ8loVJKAkuzswl5js8BHda79bIb2b84ehU8IjXw==}
+    peerDependencies:
+      react: 19.0.0
+      tslib: '*'
+
+  react-use@17.6.0:
+    resolution: {integrity: sha512-OmedEScUMKFfzn1Ir8dBxiLLSOzhKe/dPZwVxcujweSj45aNM7BEGPb9BEVIgVEqEXx6f3/TsXzwIktNgUR02g==}
+    peerDependencies:
+      react: 19.0.0
+      react-dom: 19.0.0
+
   react@19.0.0:
     resolution: {integrity: sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==}
     engines: {node: '>=0.10.0'}
@@ -3723,6 +3781,9 @@ packages:
     resolution: {integrity: sha512-efCx3b+0Z69/LGJmm9Yvi4cqEdxnoGnxYxGxBghkkTTFeXRtTCmmhO0AnAfHz59k957uTSuy8WaHqOs8wbYUWg==}
     engines: {node: '>=6'}
 
+  resize-observer-polyfill@1.5.1:
+    resolution: {integrity: sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==}
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -3754,6 +3815,9 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  rtl-css-js@1.16.1:
+    resolution: {integrity: sha512-lRQgou1mu19e+Ya0LsTvKrVJ5TYUbqCVPAiImX3UfLTenarvPUl1QFdvu5Z3PYmHT9RCcwIfbjRQBntExyj3Zg==}
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -3772,6 +3836,10 @@ packages:
   scheduler@0.25.0:
     resolution: {integrity: sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==}
 
+  screenfull@5.2.0:
+    resolution: {integrity: sha512-9BakfsO2aUQN2K9Fdbj87RJIEZ82Q9IGim7FqM5OsebfoFC6ZHXgDq/KvniuLTPdeM8wY2o6Dj3WQ7KeQCj3cA==}
+    engines: {node: '>=0.10.0'}
+
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
@@ -3785,6 +3853,10 @@ packages:
     resolution: {integrity: sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==}
     engines: {node: '>=10'}
     hasBin: true
+
+  set-harmonic-interval@1.0.1:
+    resolution: {integrity: sha512-AhICkFV84tBP1aWqPwLZqFvAwqEoVA9kxNMniGEUvzOlm4vLmOFLiTT3UZ6bziJTy4bOVpzWGTfSCbmaayGx8g==}
+    engines: {node: '>=6.9'}
 
   sharp@0.33.5:
     resolution: {integrity: sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==}
@@ -3837,6 +3909,10 @@ packages:
   source-map-support@0.5.21:
     resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
 
+  source-map@0.5.6:
+    resolution: {integrity: sha512-MjZkVp0NHr5+TPihLcadqnlVoGIoWo4IBHptutGh9wI3ttUYvCG26HkSuDi+K6lsZ25syXJXcctwgyVCt//xqA==}
+    engines: {node: '>=0.10.0'}
+
   source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
@@ -3857,8 +3933,20 @@ packages:
   sprintf-js@1.1.3:
     resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
 
+  stack-generator@2.0.10:
+    resolution: {integrity: sha512-mwnua/hkqM6pF4k8SnmZ2zfETsRUpWXREfA/goT8SLCV4iOFa4bzOX2nDipWAZFPTjLvQB82f5yaodMVhK0yJQ==}
+
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  stackframe@1.3.4:
+    resolution: {integrity: sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==}
+
+  stacktrace-gps@3.1.2:
+    resolution: {integrity: sha512-GcUgbO4Jsqqg6RxfyTHFiPxdPqF+3LFmQhm7MgCuYQOYuWyqxo5pwRPz5d/u6/WYJdEnWfK4r+jGbyD8TSggXQ==}
+
+  stacktrace-js@2.0.2:
+    resolution: {integrity: sha512-Je5vBeY4S1r/RnLydLl0TBTi3F2qdfWmYsGvtfZgEI+SCprPppaIhQf5nGcal4gI4cGpCV/duLcAzT1np6sQqg==}
 
   std-env@3.9.0:
     resolution: {integrity: sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==}
@@ -3902,6 +3990,9 @@ packages:
   style-to-object@1.0.9:
     resolution: {integrity: sha512-G4qppLgKu/k6FwRpHiGiKPaPTFcG3g4wNVX/Qsfu+RqQM30E7Tyu/TEgxcL9PNLF5pdRLwQdE3YKKf+KF2Dzlw==}
 
+  stylis@4.3.6:
+    resolution: {integrity: sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==}
+
   supports-color@10.0.0:
     resolution: {integrity: sha512-HRVVSbCCMbj7/kdWF9Q+bbckjBHLtHMEoJWlkmYzzdwhYMkjkOwubLM6t7NbWKjgKamGDrWL1++KrjUO1t9oAQ==}
     engines: {node: '>=18'}
@@ -3934,6 +4025,10 @@ packages:
     resolution: {integrity: sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==}
     engines: {node: '>=18'}
 
+  throttle-debounce@3.0.1:
+    resolution: {integrity: sha512-dTEWWNu6JmeVXY0ZYoPuH5cRIwc0MeGbJwah9KUNYSJwommQpCzTySTpEe8Gs1J23aeWEuAobe4Ag7EHVt/LOg==}
+    engines: {node: '>=10'}
+
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -3960,6 +4055,9 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  toggle-selection@1.0.6:
+    resolution: {integrity: sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ==}
+
   toml@3.0.0:
     resolution: {integrity: sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==}
 
@@ -3978,6 +4076,9 @@ packages:
     engines: {node: '>=18.12'}
     peerDependencies:
       typescript: '>=4.8.4'
+
+  ts-easing@0.2.0:
+    resolution: {integrity: sha512-Z86EW+fFFh/IFB1fqQ3/+7Zpf9t2ebOAxNI/V6Wo7r5gqiqtxmgTlQ1qbqQcjLKYeSHPTsEmvlJUDg/EuL0uHQ==}
 
   tslib@1.9.3:
     resolution: {integrity: sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==}
@@ -6206,6 +6307,8 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
+  '@types/js-cookie@2.2.7': {}
+
   '@types/js-cookie@3.0.6': {}
 
   '@types/json-schema@7.0.15': {}
@@ -6438,6 +6541,8 @@ snapshots:
       '@vitest/pretty-format': 3.2.4
       loupe: 3.1.4
       tinyrainbow: 2.0.0
+
+  '@xobotyi/scrollbar-width@1.9.5': {}
 
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
@@ -6693,6 +6798,10 @@ snapshots:
 
   cookie@1.0.2: {}
 
+  copy-to-clipboard@3.3.3:
+    dependencies:
+      toggle-selection: 1.0.6
+
   crelt@1.0.6: {}
 
   croner@4.1.97: {}
@@ -6702,6 +6811,15 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  css-in-js-utils@3.1.0:
+    dependencies:
+      hyphenate-style-name: 1.1.0
+
+  css-tree@1.1.3:
+    dependencies:
+      mdn-data: 2.0.14
+      source-map: 0.6.1
 
   css.escape@1.5.1: {}
 
@@ -6790,6 +6908,10 @@ snapshots:
   entities@4.5.0: {}
 
   error-stack-parser-es@1.0.5: {}
+
+  error-stack-parser@2.1.4:
+    dependencies:
+      stackframe: 1.3.4
 
   es-module-lexer@1.7.0: {}
 
@@ -6987,6 +7109,10 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-shallow-equal@1.0.0: {}
+
+  fastest-stable-stringify@2.0.2: {}
+
   fastq@1.19.1:
     dependencies:
       reusify: 1.1.0
@@ -7166,6 +7292,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  hyphenate-style-name@1.1.0: {}
+
   iconv-lite@0.4.24:
     dependencies:
       safer-buffer: 2.1.2
@@ -7188,6 +7316,10 @@ snapshots:
   ini@4.1.3: {}
 
   inline-style-parser@0.2.4: {}
+
+  inline-style-prefixer@7.0.1:
+    dependencies:
+      css-in-js-utils: 3.1.0
 
   ip-address@9.0.5:
     dependencies:
@@ -7247,6 +7379,8 @@ snapshots:
   isexe@2.0.0: {}
 
   jiti@2.4.2: {}
+
+  js-cookie@2.2.1: {}
 
   js-cookie@3.0.5: {}
 
@@ -7468,6 +7602,8 @@ snapshots:
     dependencies:
       '@types/mdast': 4.0.4
 
+  mdn-data@2.0.14: {}
+
   merge2@1.4.1: {}
 
   micromark-core-commonmark@2.0.3:
@@ -7683,6 +7819,19 @@ snapshots:
   multipasta@0.2.7: {}
 
   mute-stream@0.0.8: {}
+
+  nano-css@5.6.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.4
+      css-tree: 1.1.3
+      csstype: 3.1.3
+      fastest-stable-stringify: 2.0.2
+      inline-style-prefixer: 7.0.1
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+      rtl-css-js: 1.16.1
+      stacktrace-js: 2.0.2
+      stylis: 4.3.6
 
   nanoid@3.3.11: {}
 
@@ -8039,6 +8188,30 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
+  react-universal-interface@0.6.2(react@19.0.0)(tslib@2.8.1):
+    dependencies:
+      react: 19.0.0
+      tslib: 2.8.1
+
+  react-use@17.6.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
+    dependencies:
+      '@types/js-cookie': 2.2.7
+      '@xobotyi/scrollbar-width': 1.9.5
+      copy-to-clipboard: 3.3.3
+      fast-deep-equal: 3.1.3
+      fast-shallow-equal: 1.0.0
+      js-cookie: 2.2.1
+      nano-css: 5.6.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+      react-universal-interface: 0.6.2(react@19.0.0)(tslib@2.8.1)
+      resize-observer-polyfill: 1.5.1
+      screenfull: 5.2.0
+      set-harmonic-interval: 1.0.1
+      throttle-debounce: 3.0.1
+      ts-easing: 0.2.0
+      tslib: 2.8.1
+
   react@19.0.0: {}
 
   read@1.0.7:
@@ -8087,6 +8260,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  resize-observer-polyfill@1.5.1: {}
+
   resolve-from@4.0.0: {}
 
   resolve@1.22.10:
@@ -8132,6 +8307,10 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.45.0
       fsevents: 2.3.3
 
+  rtl-css-js@1.16.1:
+    dependencies:
+      '@babel/runtime': 7.27.6
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -8146,6 +8325,8 @@ snapshots:
 
   scheduler@0.25.0: {}
 
+  screenfull@5.2.0: {}
+
   semver@6.3.1: {}
 
   semver@7.5.4:
@@ -8153,6 +8334,8 @@ snapshots:
       lru-cache: 6.0.0
 
   semver@7.7.2: {}
+
+  set-harmonic-interval@1.0.1: {}
 
   sharp@0.33.5:
     dependencies:
@@ -8230,6 +8413,8 @@ snapshots:
       buffer-from: 1.1.2
       source-map: 0.6.1
 
+  source-map@0.5.6: {}
+
   source-map@0.6.1: {}
 
   source-map@0.7.4: {}
@@ -8242,7 +8427,24 @@ snapshots:
 
   sprintf-js@1.1.3: {}
 
+  stack-generator@2.0.10:
+    dependencies:
+      stackframe: 1.3.4
+
   stackback@0.0.2: {}
+
+  stackframe@1.3.4: {}
+
+  stacktrace-gps@3.1.2:
+    dependencies:
+      source-map: 0.5.6
+      stackframe: 1.3.4
+
+  stacktrace-js@2.0.2:
+    dependencies:
+      error-stack-parser: 2.1.4
+      stack-generator: 2.0.10
+      stacktrace-gps: 3.1.2
 
   std-env@3.9.0: {}
 
@@ -8287,6 +8489,8 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.4
 
+  stylis@4.3.6: {}
+
   supports-color@10.0.0: {}
 
   supports-color@7.2.0:
@@ -8313,6 +8517,8 @@ snapshots:
       mkdirp: 3.0.1
       yallist: 5.0.0
 
+  throttle-debounce@3.0.1: {}
+
   tinybench@2.9.0: {}
 
   tinyexec@0.3.2: {}
@@ -8332,6 +8538,8 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
+  toggle-selection@1.0.6: {}
+
   toml@3.0.0: {}
 
   totalist@3.0.1: {}
@@ -8343,6 +8551,8 @@ snapshots:
   ts-api-utils@2.1.0(typescript@5.8.3):
     dependencies:
       typescript: 5.8.3
+
+  ts-easing@0.2.0: {}
 
   tslib@1.9.3: {}
 

--- a/src/components/notebook/cell/CodeCell.tsx
+++ b/src/components/notebook/cell/CodeCell.tsx
@@ -302,7 +302,7 @@ export const CodeCell: React.FC<CodeCellProps> = ({
               <Editor
                 localSource={localSource}
                 handleSourceChange={handleSourceChange}
-                updateSource={updateSource}
+                onBlur={updateSource}
                 handleFocus={handleFocus}
                 cell={cell}
                 autoFocus={autoFocus}

--- a/src/components/notebook/cell/MarkdownCell.tsx
+++ b/src/components/notebook/cell/MarkdownCell.tsx
@@ -255,10 +255,6 @@ export const MarkdownCell: React.FC<MarkdownCellProps> = ({
                 autoFocus={autoFocus}
                 keyMap={extendedKeyMap}
                 onBlur={updateSource}
-                onClickOutside={() => {
-                  setIsEditing(false);
-                  updateSource();
-                }}
               />
             </ErrorBoundary>
           </div>

--- a/src/components/notebook/cell/MarkdownCell.tsx
+++ b/src/components/notebook/cell/MarkdownCell.tsx
@@ -3,7 +3,7 @@ import { useCellKeyboardNavigation } from "@/hooks/useCellKeyboardNavigation.js"
 import { useCellOutputs } from "@/hooks/useCellOutputs.js";
 import { useStore } from "@livestore/react";
 import { events, tables } from "@runt/schema";
-import React, { useCallback } from "react";
+import React, { useCallback, useState } from "react";
 
 import { useCurrentUserId } from "@/hooks/useCurrentUser.js";
 import { useUserRegistry } from "@/hooks/useUserRegistry.js";
@@ -14,6 +14,7 @@ import { CellTypeSelector } from "./shared/CellTypeSelector.js";
 import { Editor } from "./shared/Editor.js";
 import { PresenceBookmarks } from "./shared/PresenceBookmarks.js";
 import { MarkdownToolbar } from "./toolbars/MarkdownToolbar.js";
+import { MarkdownRenderer } from "@/components/outputs/MarkdownRenderer.js";
 
 type CellType = typeof tables.cells.Type;
 
@@ -44,6 +45,7 @@ export const MarkdownCell: React.FC<MarkdownCellProps> = ({
   const { store } = useStore();
   const currentUserId = useCurrentUserId();
   const { getUsersOnCell, getUserColor } = useUserRegistry();
+  const [isEditing, setIsEditing] = useState(false);
 
   // Get users present on this cell (excluding current user)
   const usersOnCell = getUsersOnCell(cell.id).filter(
@@ -138,7 +140,10 @@ export const MarkdownCell: React.FC<MarkdownCellProps> = ({
       <div className="cell-header mb-2 flex items-center justify-between pr-1 pl-6 sm:pr-4">
         <div className="flex items-center gap-3">
           <CellTypeSelector cell={cell} onCellTypeChange={changeCellType} />
-          <MarkdownToolbar />
+          <MarkdownToolbar
+            onEdit={() => setIsEditing(true)}
+            onPreview={() => setIsEditing(false)}
+          />
           <PresenceBookmarks
             usersOnCell={usersOnCell}
             getUserColor={getUserColor}
@@ -161,7 +166,7 @@ export const MarkdownCell: React.FC<MarkdownCellProps> = ({
       {/* Cell Content */}
       <div className="relative">
         {/* Editor Content Area */}
-        {cell.sourceVisible && (
+        {cell.sourceVisible && isEditing && (
           <div className="cell-content bg-white py-1 pl-4 transition-colors">
             <ErrorBoundary fallback={<div>Error rendering editor</div>}>
               <Editor
@@ -174,6 +179,11 @@ export const MarkdownCell: React.FC<MarkdownCellProps> = ({
                 keyMap={keyMap}
               />
             </ErrorBoundary>
+          </div>
+        )}
+        {cell.sourceVisible && !isEditing && (
+          <div className="cell-content bg-white py-1 pl-4 transition-colors">
+            <MarkdownRenderer content={localSource} />
           </div>
         )}
       </div>

--- a/src/components/notebook/cell/MarkdownCell.tsx
+++ b/src/components/notebook/cell/MarkdownCell.tsx
@@ -148,7 +148,6 @@ export const MarkdownCell: React.FC<MarkdownCellProps> = ({
       {
         key: "Escape",
         run: () => {
-          console.log(cell.source, localSource);
           // TODO: undo changes
           setLocalSource(cell.source);
           setTimeout(() => {

--- a/src/components/notebook/cell/MarkdownCell.tsx
+++ b/src/components/notebook/cell/MarkdownCell.tsx
@@ -261,7 +261,7 @@ export const MarkdownCell: React.FC<MarkdownCellProps> = ({
         )}
         {cell.sourceVisible && !isEditing && (
           <div
-            className="cell-content bg-white py-1 pl-4 transition-colors"
+            className="cell-content bg-white py-1 pr-4 pl-4 transition-colors"
             onDoubleClick={() => setIsEditing(true)}
           >
             <MarkdownRenderer content={localSource} />

--- a/src/components/notebook/cell/MarkdownCell.tsx
+++ b/src/components/notebook/cell/MarkdownCell.tsx
@@ -172,17 +172,27 @@ export const MarkdownCell: React.FC<MarkdownCellProps> = ({
               <Editor
                 localSource={localSource}
                 handleSourceChange={handleSourceChange}
-                updateSource={updateSource}
                 handleFocus={handleFocus}
                 cell={cell}
                 autoFocus={autoFocus}
                 keyMap={keyMap}
+                onBlur={() => {
+                  setIsEditing(false);
+                  updateSource();
+                }}
+                onClickOutside={() => {
+                  setIsEditing(false);
+                  updateSource();
+                }}
               />
             </ErrorBoundary>
           </div>
         )}
         {cell.sourceVisible && !isEditing && (
-          <div className="cell-content bg-white py-1 pl-4 transition-colors">
+          <div
+            className="cell-content bg-white py-1 pl-4 transition-colors"
+            onDoubleClick={() => setIsEditing(true)}
+          >
             <MarkdownRenderer content={localSource} />
           </div>
         )}

--- a/src/components/notebook/cell/shared/CellContainer.tsx
+++ b/src/components/notebook/cell/shared/CellContainer.tsx
@@ -1,5 +1,5 @@
-import React, { ReactNode } from "react";
 import { tables } from "@runt/schema";
+import { forwardRef, ReactNode } from "react";
 import "./PresenceIndicators.css";
 
 interface CellContainerProps {
@@ -12,42 +12,50 @@ interface CellContainerProps {
   focusBgColor?: string;
 }
 
-export const CellContainer: React.FC<CellContainerProps> = ({
-  cell,
-  autoFocus = false,
-  contextSelectionMode = false,
-  onFocus,
-  children,
-  focusColor = "bg-primary/60",
-  focusBgColor = "bg-primary/5",
-}) => {
-  return (
-    <div
-      className={`cell-container group relative mb-2 pt-2 transition-all duration-200 sm:mb-3 ${
-        autoFocus && !contextSelectionMode ? focusBgColor : "hover:bg-muted/10"
-      } ${contextSelectionMode && !cell.aiContextVisible ? "opacity-60" : ""} ${
-        contextSelectionMode
-          ? cell.aiContextVisible
-            ? "bg-purple-50/30 ring-2 ring-purple-300"
-            : "bg-gray-50/30 ring-2 ring-gray-300"
-          : ""
-      }`}
-      onClick={contextSelectionMode ? onFocus : undefined}
-      style={{
-        position: "relative",
-      }}
-    >
-      {/* Custom left border with controlled height */}
+export const CellContainer = forwardRef<HTMLDivElement, CellContainerProps>(
+  (
+    {
+      cell,
+      autoFocus = false,
+      contextSelectionMode = false,
+      onFocus,
+      children,
+      focusColor = "bg-primary/60",
+      focusBgColor = "bg-primary/5",
+    },
+    ref
+  ) => {
+    return (
       <div
-        className={`cell-border absolute top-0 left-3 w-0.5 transition-all duration-200 sm:left-0 ${
-          autoFocus && !contextSelectionMode ? focusColor : "bg-border/30"
+        ref={ref}
+        className={`cell-container group relative mb-2 pt-2 transition-all duration-200 sm:mb-3 ${
+          autoFocus && !contextSelectionMode
+            ? focusBgColor
+            : "hover:bg-muted/10"
+        } ${contextSelectionMode && !cell.aiContextVisible ? "opacity-60" : ""} ${
+          contextSelectionMode
+            ? cell.aiContextVisible
+              ? "bg-purple-50/30 ring-2 ring-purple-300"
+              : "bg-gray-50/30 ring-2 ring-gray-300"
+            : ""
         }`}
+        onClick={contextSelectionMode ? onFocus : undefined}
         style={{
-          height: "100%", // Will be controlled by content
+          position: "relative",
         }}
-      />
+      >
+        {/* Custom left border with controlled height */}
+        <div
+          className={`cell-border absolute top-0 left-3 w-0.5 transition-all duration-200 sm:left-0 ${
+            autoFocus && !contextSelectionMode ? focusColor : "bg-border/30"
+          }`}
+          style={{
+            height: "100%", // Will be controlled by content
+          }}
+        />
 
-      {children}
-    </div>
-  );
-};
+        {children}
+      </div>
+    );
+  }
+);

--- a/src/components/notebook/cell/shared/Editor.tsx
+++ b/src/components/notebook/cell/shared/Editor.tsx
@@ -20,7 +20,6 @@ export function Editor({
   cell,
   autoFocus,
   keyMap,
-  onClickOutside,
 }: {
   localSource: string;
   handleSourceChange: (source: string) => void;
@@ -29,7 +28,6 @@ export function Editor({
   cell: typeof tables.cells.Type;
   autoFocus: boolean;
   keyMap: KeyBinding[];
-  onClickOutside?: () => void;
 }) {
   const [isMaximized, setIsMaximized] = useState(false);
 
@@ -48,7 +46,6 @@ export function Editor({
             keyMap={keyMap}
             onBlur={onBlur}
             enableLineWrapping={cell.cellType === "markdown"}
-            onClickOutside={onClickOutside}
           />
         </ErrorBoundary>
         <MaxMinButton

--- a/src/components/notebook/cell/shared/Editor.tsx
+++ b/src/components/notebook/cell/shared/Editor.tsx
@@ -15,19 +15,21 @@ const ErrorFallback = () => {
 export function Editor({
   localSource,
   handleSourceChange,
-  updateSource,
   handleFocus,
+  onBlur,
   cell,
   autoFocus,
   keyMap,
+  onClickOutside,
 }: {
   localSource: string;
   handleSourceChange: (source: string) => void;
-  updateSource: () => void;
+  onBlur: () => void;
   handleFocus: () => void;
   cell: typeof tables.cells.Type;
   autoFocus: boolean;
   keyMap: KeyBinding[];
+  onClickOutside?: () => void;
 }) {
   const [isMaximized, setIsMaximized] = useState(false);
 
@@ -44,8 +46,9 @@ export function Editor({
             autoFocus={autoFocus}
             onFocus={handleFocus}
             keyMap={keyMap}
-            onBlur={updateSource}
+            onBlur={onBlur}
             enableLineWrapping={cell.cellType === "markdown"}
+            onClickOutside={onClickOutside}
           />
         </ErrorBoundary>
         <MaxMinButton
@@ -101,7 +104,7 @@ export function Editor({
                 onValueChange={handleSourceChange}
                 autoFocus={true}
                 onFocus={handleFocus}
-                onBlur={updateSource}
+                onBlur={onBlur}
                 enableLineWrapping={cell.cellType === "markdown"}
               />
             </ErrorBoundary>

--- a/src/components/notebook/cell/toolbars/MarkdownToolbar.tsx
+++ b/src/components/notebook/cell/toolbars/MarkdownToolbar.tsx
@@ -1,11 +1,17 @@
+import { Button } from "@/components/ui/button";
+import { Edit3, Eye } from "lucide-react";
 import React from "react";
 // import { Badge } from "@/components/ui/badge";
 
-interface MarkdownToolbarProps {}
+interface MarkdownToolbarProps {
+  onEdit: () => void;
+  onPreview: () => void;
+}
 
-export const MarkdownToolbar: React.FC<MarkdownToolbarProps> = (
-  _props: MarkdownToolbarProps
-) => {
+export const MarkdownToolbar: React.FC<MarkdownToolbarProps> = ({
+  onEdit,
+  onPreview,
+}: MarkdownToolbarProps) => {
   return (
     <div className="flex items-center gap-2">
       {/* <Badge
@@ -15,6 +21,12 @@ export const MarkdownToolbar: React.FC<MarkdownToolbarProps> = (
       >
         markdown
       </Badge> */}
+      <Button variant="outline" size="xs" onClick={onEdit}>
+        <Edit3 className="size-3" />
+      </Button>
+      <Button variant="outline" size="xs" title="Preview" onClick={onPreview}>
+        <Eye className="size-3" />
+      </Button>
     </div>
   );
 };

--- a/src/components/notebook/cell/toolbars/MarkdownToolbar.tsx
+++ b/src/components/notebook/cell/toolbars/MarkdownToolbar.tsx
@@ -1,17 +1,7 @@
-import { Button } from "@/components/ui/button";
-import { Edit3, Eye } from "lucide-react";
 import React from "react";
 // import { Badge } from "@/components/ui/badge";
 
-interface MarkdownToolbarProps {
-  onEdit: () => void;
-  onPreview: () => void;
-}
-
-export const MarkdownToolbar: React.FC<MarkdownToolbarProps> = ({
-  onEdit,
-  onPreview,
-}: MarkdownToolbarProps) => {
+export const MarkdownToolbar: React.FC = () => {
   return (
     <div className="flex items-center gap-2">
       {/* <Badge
@@ -21,12 +11,6 @@ export const MarkdownToolbar: React.FC<MarkdownToolbarProps> = ({
       >
         markdown
       </Badge> */}
-      <Button variant="outline" size="xs" onClick={onEdit}>
-        <Edit3 className="size-3" />
-      </Button>
-      <Button variant="outline" size="xs" title="Preview" onClick={onPreview}>
-        <Eye className="size-3" />
-      </Button>
     </div>
   );
 };

--- a/src/components/notebook/codemirror/CodeMirrorEditor.tsx
+++ b/src/components/notebook/codemirror/CodeMirrorEditor.tsx
@@ -27,7 +27,6 @@ type CodeMirrorEditorProps = {
   maxHeight?: string;
   enableLineWrapping?: boolean;
   disableAutocompletion?: boolean;
-  onClickOutside?: () => void;
 };
 
 function languageExtension(language: SupportedLanguage) {
@@ -54,10 +53,7 @@ export const CodeMirrorEditor: React.FC<CodeMirrorEditorProps> = ({
   maxHeight,
   enableLineWrapping = false,
   disableAutocompletion = false,
-  onClickOutside,
 }) => {
-  // TODO: implement onClickOutside
-
   const editorRef = useRef<HTMLDivElement | null>(null);
 
   const langExtension = useMemo(() => languageExtension(language), [language]);
@@ -98,7 +94,7 @@ export const CodeMirrorEditor: React.FC<CodeMirrorEditorProps> = ({
   );
 
   const handleFocus = useCallback(() => {
-    // editorRef.current?.scrollIntoView({ block: "nearest" });
+    editorRef.current?.scrollIntoView({ block: "nearest" });
     onFocus?.();
   }, [onFocus]);
 

--- a/src/components/notebook/codemirror/CodeMirrorEditor.tsx
+++ b/src/components/notebook/codemirror/CodeMirrorEditor.tsx
@@ -27,6 +27,7 @@ type CodeMirrorEditorProps = {
   maxHeight?: string;
   enableLineWrapping?: boolean;
   disableAutocompletion?: boolean;
+  onClickOutside?: () => void;
 };
 
 function languageExtension(language: SupportedLanguage) {
@@ -53,7 +54,10 @@ export const CodeMirrorEditor: React.FC<CodeMirrorEditorProps> = ({
   maxHeight,
   enableLineWrapping = false,
   disableAutocompletion = false,
+  onClickOutside,
 }) => {
+  // TODO: implement onClickOutside
+
   const editorRef = useRef<HTMLDivElement | null>(null);
 
   const langExtension = useMemo(() => languageExtension(language), [language]);
@@ -94,7 +98,7 @@ export const CodeMirrorEditor: React.FC<CodeMirrorEditorProps> = ({
   );
 
   const handleFocus = useCallback(() => {
-    editorRef.current?.scrollIntoView({ block: "nearest" });
+    // editorRef.current?.scrollIntoView({ block: "nearest" });
     onFocus?.();
   }, [onFocus]);
 

--- a/src/components/outputs/MarkdownRenderer.tsx
+++ b/src/components/outputs/MarkdownRenderer.tsx
@@ -222,6 +222,11 @@ export const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
               </h6>
             );
           },
+          hr({ ...props }) {
+            return (
+              <hr className="!my-4 !border-t !border-gray-300" {...props} />
+            );
+          },
         }}
       >
         {content}

--- a/src/hooks/useCellKeyboardNavigation.ts
+++ b/src/hooks/useCellKeyboardNavigation.ts
@@ -90,9 +90,16 @@ export const useCellKeyboardNavigation = ({
   }, [onExecute, onFocusNext, onFocusPrevious, onDeleteCell, onUpdateSource]);
 
   const handleKeyDown = useCallback(
-    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-      const textarea = e.currentTarget;
-      const { selectionStart, selectionEnd, value } = textarea;
+    (e: React.KeyboardEvent<HTMLElement>) => {
+      const isTextarea = e.currentTarget instanceof HTMLTextAreaElement;
+
+      const textarea = isTextarea
+        ? (e.currentTarget as HTMLTextAreaElement)
+        : null;
+
+      const { selectionStart, selectionEnd, value } = isTextarea
+        ? (e.currentTarget as HTMLTextAreaElement)
+        : { selectionStart: 0, selectionEnd: 0, value: "" };
 
       if (
         e.key === "Backspace" &&
@@ -136,7 +143,7 @@ export const useCellKeyboardNavigation = ({
           } else {
             // Not at beginning of first line - move to beginning
             e.preventDefault();
-            textarea.setSelectionRange(0, 0);
+            textarea?.setSelectionRange(0, 0);
             return;
           }
         }
@@ -165,7 +172,7 @@ export const useCellKeyboardNavigation = ({
           } else {
             // Not at end of last line - move to end
             e.preventDefault();
-            textarea.setSelectionRange(value.length, value.length);
+            textarea?.setSelectionRange(value.length, value.length);
             return;
           }
         }


### PR DESCRIPTION
https://github.com/user-attachments/assets/4665369c-3988-44c9-8cef-de8d1f345025

- auto-focus "edit" button when switching out of preview mode
- double-click to enter edit mode
- click outside cell container to exit edit mode
- Keyboard shortcut support
  - cmd-enter "runs" / renders markdown
  - arrow keys work when focus is in the cell, even when in preview mode
  - esc key cancels editing
  - arrow keys pressed from another cell cause markdown cell to enter edit mode
  
misc:
- Add tailwind hr markdown element
- [Add padding to right of markdown render](https://github.com/runtimed/anode/pull/245/commits/28b2bfca2bd1858f3fb7cdfbc81b001700c5fab4) 
[28b2bfc](https://github.com/runtimed/anode/pull/245/commits/28b2bfca2bd1858f3fb7cdfbc81b001700c5fab4)
so it doesn't hit the edge of window in mobile