### PR TITLE
Remove potentially unsafe type assertions

### DIFF
--- a/src/components/notebook/DebugPanel.tsx
+++ b/src/components/notebook/DebugPanel.tsx
@@ -4,6 +4,7 @@ import { queryDb, sql, Schema } from "@livestore/livestore";
 
 import {
   CellData,
+  ExecutionQueueData,
   RuntimeSessionData,
   NotebookMetadataData,
   tables,
@@ -15,9 +16,9 @@ import { Button } from "@/components/ui/button";
 
 interface DebugPanelProps {
   metadata: readonly NotebookMetadataData[];
-  cells: CellData[];
-  allRuntimeSessions: RuntimeSessionData[];
-  executionQueue: any[];
+  cells: readonly CellData[];
+  allRuntimeSessions: readonly RuntimeSessionData[];
+  executionQueue: readonly ExecutionQueueData[];
   currentNotebookId: string;
   runtimeHealth: string;
 }

--- a/src/components/notebook/NotebookViewer.tsx
+++ b/src/components/notebook/NotebookViewer.tsx
@@ -58,15 +58,15 @@ export const NotebookViewer: React.FC<NotebookViewerProps> = ({
 
   const cells = store.useQuery(
     queryDb(tables.cells.select().orderBy("position", "asc"))
-  ) as CellData[];
+  );
   const metadata = store.useQuery(queryDb(tables.notebookMetadata.select()));
   const runtimeSessions = store.useQuery(
     queryDb(tables.runtimeSessions.select().where({ isActive: true }))
-  ) as RuntimeSessionData[];
+  );
   // Get all runtime sessions for debug panel
   const allRuntimeSessions = store.useQuery(
     queryDb(tables.runtimeSessions.select())
-  ) as RuntimeSessionData[];
+  );
   // Get execution queue for debug panel
   const executionQueue = store.useQuery(
     queryDb(tables.executionQueue.select().orderBy("id", "desc"))
@@ -806,13 +806,7 @@ export const NotebookViewer: React.FC<NotebookViewerProps> = ({
                   <VirtualizedCellList
                     cells={cells}
                     focusedCellId={focusedCellId}
-                    onAddCell={(afterCellId, cellType, position) =>
-                      addCell(
-                        afterCellId,
-                        cellType as "code" | "markdown" | "sql" | "ai",
-                        position
-                      )
-                    }
+                    onAddCell={addCell}
                     onDeleteCell={deleteCell}
                     onMoveUp={(cellId) => moveCell(cellId, "up")}
                     onMoveDown={(cellId) => moveCell(cellId, "down")}

--- a/src/components/notebook/VirtualizedCellList.tsx
+++ b/src/components/notebook/VirtualizedCellList.tsx
@@ -12,11 +12,11 @@ import { Cell } from "./cell/Cell.js";
 import { CellBetweener } from "./cell/CellBetweener.js";
 
 interface VirtualizedCellListProps {
-  cells: CellData[];
+  cells: readonly CellData[];
   focusedCellId: string | null;
   onAddCell: (
     cellId?: string,
-    cellType?: string,
+    cellType?: "code" | "markdown" | "sql" | "ai",
     position?: "before" | "after"
   ) => void;
   onDeleteCell: (cellId: string) => void;


### PR DESCRIPTION
Removes uses of `any` and some type assertions by requiring
`readonly` types as props to match livestore query return types.
