### PR TITLE
Change automation client to pink NotebookPen icon

### DIFF
--- a/src/components/notebook/NotebookViewer.tsx
+++ b/src/components/notebook/NotebookViewer.tsx
@@ -24,7 +24,7 @@ import {
   Database,
   FileText,
   Filter,
-  Play,
+  NotebookPen,
   Square,
   Terminal,
   X,
@@ -370,7 +370,7 @@ export const NotebookViewer: React.FC<NotebookViewerProps> = ({
                           : isTuiClient
                             ? "#6366f1"
                             : isAutomationClient
-                              ? "#ea580c"
+                              ? "#ec4899"
                               : getUserColor(user.id),
                       }}
                       title={
@@ -392,8 +392,8 @@ export const NotebookViewer: React.FC<NotebookViewerProps> = ({
                           <Terminal className="size-4 text-indigo-700" />
                         </div>
                       ) : isAutomationClient ? (
-                        <div className="flex size-8 items-center justify-center rounded-full bg-orange-100">
-                          <Play className="size-4 text-orange-700" />
+                        <div className="flex size-8 items-center justify-center rounded-full bg-pink-100">
+                          <NotebookPen className="size-4 text-pink-700" />
                         </div>
                       ) : userInfo?.picture ? (
                         <img


### PR DESCRIPTION
- Replace orange Play icon with pink NotebookPen icon
- Less actionable appearance, better represents notebook execution
- Pink color distinguishes from other client types
- NotebookPen conveys 'writing/executing notebook' concept