### PR TITLE
Fix unnecessary useMemo dependency in MarkdownCell

### DIFF
--- a/src/components/notebook/cell/MarkdownCell.tsx
+++ b/src/components/notebook/cell/MarkdownCell.tsx
@@ -170,7 +170,6 @@ export const MarkdownCell: React.FC<MarkdownCellProps> = ({
     ];
   }, [
     cell.source,
-    localSource,
     keyMap,
     setLocalSource,
     updateSource,


### PR DESCRIPTION
## Summary
- Remove unnecessary `localSource` dependency from useMemo in MarkdownCell component
- Resolves React Hook warning about unnecessary dependency