### PR TITLE
Fix artifact image rendering and remove zoom functionality

### DIFF
--- a/src/components/outputs/ImageOutput.tsx
+++ b/src/components/outputs/ImageOutput.tsx
@@ -1,5 +1,4 @@
-import React, { useState } from "react";
-import { X, ZoomIn } from "lucide-react";
+import React from "react";
 
 interface ImageOutputProps {
   src: string;
@@ -7,62 +6,24 @@ interface ImageOutputProps {
   mediaType: "image/png" | "image/jpeg";
 }
 
-interface ZoomModalProps {
-  src: string;
-  onClose: () => void;
-}
-
-const ZoomModal: React.FC<ZoomModalProps> = ({ src, onClose }) => (
-  <div
-    className="zoom-modal bg-opacity-75 fixed inset-0 z-50 flex items-center justify-center bg-black p-4"
-    onClick={onClose}
-  >
-    <div className="relative max-h-full max-w-full">
-      <button
-        onClick={onClose}
-        className="bg-opacity-50 hover:bg-opacity-70 absolute top-2 right-2 z-10 rounded-full bg-black p-2 text-white"
-      >
-        <X className="h-4 w-4" />
-      </button>
-      <img
-        src={src}
-        alt="Zoomed view"
-        className="max-h-full max-w-full object-contain"
-        onClick={(e) => e.stopPropagation()}
-      />
-    </div>
-  </div>
-);
-
 export const ImageOutput: React.FC<ImageOutputProps> = ({
   src,
   alt = "Output image",
   mediaType,
 }) => {
-  const [zoomedImage, setZoomedImage] = useState<string | null>(null);
-
-  const imageSrc = src.startsWith("data:")
-    ? src
-    : `data:${mediaType};base64,${src}`;
+  const imageSrc =
+    src.startsWith("data:") || src.startsWith("/") || src.startsWith("http")
+      ? src
+      : `data:${mediaType};base64,${src}`;
 
   return (
     <div className="py-2">
-      <div className="group relative max-w-full">
-        <img
-          src={imageSrc}
-          alt={alt}
-          className="zoomable-image h-auto max-w-full cursor-zoom-in transition-opacity hover:opacity-90"
-          style={{ objectFit: "contain" }}
-          onClick={() => setZoomedImage(imageSrc)}
-        />
-        <div className="bg-opacity-50 absolute top-2 right-2 rounded bg-black p-1 text-white opacity-0 transition-opacity group-hover:opacity-100">
-          <ZoomIn className="h-3 w-3" />
-        </div>
-      </div>
-
-      {zoomedImage && (
-        <ZoomModal src={zoomedImage} onClose={() => setZoomedImage(null)} />
-      )}
+      <img
+        src={imageSrc}
+        alt={alt}
+        className="h-auto max-w-full"
+        style={{ objectFit: "contain" }}
+      />
     </div>
   );
 };

--- a/src/components/outputs/RichOutput.tsx
+++ b/src/components/outputs/RichOutput.tsx
@@ -132,9 +132,8 @@ export const RichOutput: React.FC<RichOutputProps> = ({
         if (isInlineContainer(container)) {
           outputData[mimeType] = container.data;
         } else if (isArtifactContainer(container)) {
-          // For artifacts, we'll need to handle them differently
-          // For now, just mark as artifact reference
-          outputData[mimeType] = `[Artifact: ${container.artifactId}]`;
+          // Generate proper artifact URL for loading
+          outputData[mimeType] = `/api/artifacts/${container.artifactId}`;
         }
       }
     } else {


### PR DESCRIPTION
Fixes artifact images that were displaying as broken placeholder text. Artifact containers now generate proper URLs to the artifact service and ImageOutput handles both URLs and base64 data.