### PR TITLE
Update @runt/* packages to 0.8.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,7 +127,7 @@ The `@runt/schema` package provides the shared types and events between Anode an
 ### Production (JSR Package)
 
 ```json
-"@runt/schema": "jsr:^0.6.4"
+"@runt/schema": "jsr:^0.8.0"
 ```
 
 Use this for stable releases and production deployments.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,7 +82,7 @@ The `@runt/schema` package provides shared types and events between Anode and Ru
 ### Production (JSR Package)
 
 ```json
-"@runt/schema": "jsr:^0.6.4"
+"@runt/schema": "jsr:^0.8.0"
 ```
 
 Use this for stable releases and production deployments.

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ The `@runt/schema` package provides shared types and events between Anode and Ru
 **Production (JSR Package)**:
 
 ```json
-"@runt/schema": "jsr:^0.6.4"
+"@runt/schema": "jsr:^0.8.0"
 ```
 
 **Testing PR Changes (GitHub Reference)**:

--- a/docs/local-auth-testing.md
+++ b/docs/local-auth-testing.md
@@ -26,7 +26,7 @@ VITE_GOOGLE_CLIENT_ID=94663405566-1go7jlpd2ar9u9urbfirmtjv1bm0tcis.apps.googleus
 VITE_AUTH_TOKEN=
 
 # You can change this to any runtime agent command, so long as it has access to its own auth token
-VITE_RUNTIME_COMMAND="deno run --allow-all --env-file=.env jsr:@runt/pyodide-runtime-agent@^0.6.4"
+VITE_RUNTIME_COMMAND="deno run --allow-all --env-file=.env jsr:@runt/pyodide-runtime-agent@^0.8.0"
 ```
 
 Run the development server with production environment variables (using `.env.production`):

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@radix-ui/react-separator": "^1.1.7",
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-tooltip": "^1.1.6",
-    "@runt/schema": "jsr:^0.7.3",
+    "@runt/schema": "jsr:^0.8.0",
     "@tanstack/react-virtual": "^3.13.12",
     "@types/react-syntax-highlighter": "^15.5.13",
     "@uiw/codemirror-theme-github": "^4.23.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,8 +86,8 @@ importers:
         specifier: ^1.1.6
         version: 1.2.7(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@runt/schema':
-        specifier: jsr:^0.7.3
-        version: '@jsr/runt__schema@0.7.3(f9c23af240f2640c0a9abef8711d3cc6)'
+        specifier: jsr:^0.8.0
+        version: '@jsr/runt__schema@0.8.0(f9c23af240f2640c0a9abef8711d3cc6)'
       '@tanstack/react-virtual':
         specifier: ^3.13.12
         version: 3.13.12(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -1102,8 +1102,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
-  '@jsr/runt__schema@0.7.3':
-    resolution: {integrity: sha512-2AnDX11w4nrJ4e85BLYx1UYUpvMI8DryinDr9Lb3HoPZt/bLcE1eBSldY/0JxlwEfDl+lPRylAuiDGHQbjTjIg==, tarball: https://npm.jsr.io/~/11/@jsr/runt__schema/0.7.3.tgz}
+  '@jsr/runt__schema@0.8.0':
+    resolution: {integrity: sha512-DcgmNEeyqg2IwZ6nt9iXJXGfg0qXztLO7gjhAvHZzlRRedNq3+IQQ3ccaYiA/zqITX5V7JYAlc12M3xUPxFUCA==, tarball: https://npm.jsr.io/~/11/@jsr/runt__schema/0.8.0.tgz}
 
   '@lezer/common@1.2.3':
     resolution: {integrity: sha512-w7ojc8ejBqr2REPsWxJjrMFsA/ysDCFICn8zEOR9mrqzOu2amhITYuLD8ag6XZf0CFXDrhKqw7+tW8cX66NaDA==}
@@ -5256,7 +5256,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.4
 
-  '@jsr/runt__schema@0.7.3(f9c23af240f2640c0a9abef8711d3cc6)':
+  '@jsr/runt__schema@0.8.0(f9c23af240f2640c0a9abef8711d3cc6)':
     dependencies:
       '@livestore/livestore': 0.3.1(f9c23af240f2640c0a9abef8711d3cc6)
     transitivePeerDependencies:

--- a/scripts/dev-runtime.sh
+++ b/scripts/dev-runtime.sh
@@ -23,4 +23,4 @@ export LIVESTORE_SYNC_URL="ws://localhost:$DEV_PORT/livestore"
 echo "🔗 Connecting to LiveStore at: $LIVESTORE_SYNC_URL"
 
 # Run the runtime agent
-deno run --allow-all --env-file=.env "jsr:@runt/pyodide-runtime-agent@^0.6.4" "$@"
+deno run --allow-all --env-file=.env "jsr:@runt/pyodide-runtime-agent@^0.8.0" "$@"


### PR DESCRIPTION
- Update @runt/schema dependency from 0.7.3 to 0.8.0
- Update @runt/pyodide-runtime-agent references to 0.8.0
- Update all documentation examples to reference 0.8.0
- All tests passing (60/60)