### PR TITLE
Switch DebugPanel to using useQuery

### DIFF
--- a/src/components/notebook/DebugPanel.tsx
+++ b/src/components/notebook/DebugPanel.tsx
@@ -2,73 +2,80 @@ import React, { useState } from "react";
 import { useQuery, useStore } from "@livestore/react";
 import { queryDb, sql, Schema } from "@livestore/livestore";
 
-import {
-  CellData,
-  ExecutionQueueData,
-  RuntimeSessionData,
-  NotebookMetadataData,
-  tables,
-  events,
-} from "@runt/schema";
+import { tables, events } from "@runt/schema";
 import { schema } from "../../schema.js";
 import { Bug, Database } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import {
+  cellIDs$,
+  cellQuery,
+  notebookMetadata$,
+  runtimeSessions$,
+} from "@/queries/index.js";
 
-interface DebugPanelProps {
-  metadata: readonly NotebookMetadataData[];
-  cells: readonly CellData[];
-  allRuntimeSessions: readonly RuntimeSessionData[];
-  executionQueue: readonly ExecutionQueueData[];
-  currentNotebookId: string;
-  runtimeHealth: string;
-}
-
-// Hook for discovering available tables
 const useAvailableTables = () => {
-  const { store } = useStore();
-
-  // Query available tables
-  const availableTables = React.useMemo(() => {
-    try {
-      const result = store.query(
-        queryDb({
-          query: sql`SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'`,
-          schema: Schema.Array(Schema.Struct({ name: Schema.String })),
-        })
-      );
-      const tableNames = result.map((row) => row.name);
-
-      // Sort tables with __ prefixed tables at the bottom
-      return tableNames.sort((a, b) => {
-        const aHasPrefix = a.startsWith("__");
-        const bHasPrefix = b.startsWith("__");
-
-        if (aHasPrefix && !bHasPrefix) return 1;
-        if (!aHasPrefix && bHasPrefix) return -1;
-        return a.localeCompare(b);
-      });
-    } catch (error) {
-      console.error("Failed to query available tables:", error);
-      return [];
-    }
-  }, [store]);
-
-  return availableTables;
+  return useQuery(
+    queryDb(
+      {
+        query: sql`SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'`,
+        schema: Schema.Array(Schema.Struct({ name: Schema.String })),
+      },
+      { label: "debug.tables" }
+    )
+  );
 };
 
-const DebugPanel: React.FC<DebugPanelProps> = ({
-  metadata,
-  cells,
-  allRuntimeSessions,
-  executionQueue,
-  currentNotebookId,
-  runtimeHealth,
+const DebugCell = ({
+  cellId,
+  cellIndex,
+}: {
+  cellId: string;
+  cellIndex: number;
 }) => {
+  const cell = useQuery(cellQuery.byId(cellId));
+  if (!cell) {
+    return (
+      <div className="animate-pulse border-4 border-red-500 bg-red-900 p-4 text-xl font-bold text-white">
+        CELL ID '{cellId}' DOES NOT EXIST
+      </div>
+    );
+  }
+
+  return (
+    <details className="group">
+      <summary className="hover:bg-muted/50 cursor-pointer rounded p-1 font-mono text-xs">
+        {cellIndex + 1}. {cell.cellType} ({cellId.slice(-8)})
+      </summary>
+      <pre className="bg-card mt-1 overflow-x-auto rounded border p-2 text-xs">
+        {JSON.stringify(cell, null, 2)}
+      </pre>
+    </details>
+  );
+};
+
+const inflightExecutionQueue$ = queryDb(
+  tables.executionQueue
+    .select()
+    .where({
+      status: {
+        op: "IN",
+        value: ["pending", "assigned", "executing", "failed"],
+      },
+    })
+    .orderBy("id", "desc")
+);
+
+const DebugPanel: React.FC = () => {
   const { store } = useStore();
   const availableTables = useAvailableTables();
   const [buttonState, setButtonState] = useState<"default" | "success">(
     "default"
   );
+
+  const notebookMetadata = useQuery(notebookMetadata$);
+  const cellIds = useQuery(cellIDs$);
+  const runtimeSessions = useQuery(runtimeSessions$);
+  const executionQueue = useQuery(inflightExecutionQueue$);
 
   return (
     <div className="bg-muted/5 w-96 overflow-y-auto border-l">
@@ -99,9 +106,9 @@ const DebugPanel: React.FC<DebugPanelProps> = ({
           <div className="bg-card max-h-32 overflow-y-auto rounded border p-2 text-xs">
             {availableTables.length > 0 ? (
               <div className="space-y-1">
-                {availableTables.map((tableName) => (
-                  <div key={tableName} className="font-mono text-xs">
-                    • {tableName}
+                {availableTables.map(({ name }) => (
+                  <div key={name} className="font-mono text-xs">
+                    • {name}
                   </div>
                 ))}
               </div>
@@ -120,7 +127,7 @@ const DebugPanel: React.FC<DebugPanelProps> = ({
           </h4>
           <pre className="bg-card overflow-x-auto rounded border p-2 text-xs">
             {JSON.stringify(
-              Object.fromEntries(metadata.map((m) => [m.key, m.value])),
+              Object.fromEntries(notebookMetadata.map((m) => [m.key, m.value])),
               null,
               2
             )}
@@ -130,18 +137,11 @@ const DebugPanel: React.FC<DebugPanelProps> = ({
         {/* Cells Data */}
         <div>
           <h4 className="text-muted-foreground mb-2 text-xs font-medium tracking-wide uppercase">
-            Cells ({cells.length})
+            Cells ({cellIds.length})
           </h4>
           <div className="space-y-2">
-            {cells.map((cell, index) => (
-              <details key={cell.id} className="group">
-                <summary className="hover:bg-muted/50 cursor-pointer rounded p-1 font-mono text-xs">
-                  {index + 1}. {cell.cellType} ({cell.id.slice(-8)})
-                </summary>
-                <pre className="bg-card mt-1 overflow-x-auto rounded border p-2 text-xs">
-                  {JSON.stringify(cell, null, 2)}
-                </pre>
-              </details>
+            {cellIds.map((cellId, index) => (
+              <DebugCell key={cellId} cellId={cellId} cellIndex={index} />
             ))}
           </div>
         </div>
@@ -149,10 +149,10 @@ const DebugPanel: React.FC<DebugPanelProps> = ({
         {/* Runtime Sessions */}
         <div>
           <h4 className="text-muted-foreground mb-2 text-xs font-medium tracking-wide uppercase">
-            Runtime Sessions ({allRuntimeSessions.length})
+            Runtime Sessions ({runtimeSessions.length})
           </h4>
           <div className="space-y-2">
-            {allRuntimeSessions.map((session, index) => (
+            {runtimeSessions.map((session, index) => (
               <details key={session.sessionId} className="group">
                 <summary className="hover:bg-muted/50 cursor-pointer rounded p-1 font-mono text-xs">
                   {index + 1}. {session.status} ({session.sessionId.slice(-8)})
@@ -201,13 +201,6 @@ const DebugPanel: React.FC<DebugPanelProps> = ({
           <div className="bg-card space-y-1 rounded border p-2 text-xs">
             <div>
               Store ID: <code className="font-mono">{store.storeId}</code>
-            </div>
-            <div>
-              Notebook ID:{" "}
-              <code className="font-mono">{currentNotebookId}</code>
-            </div>
-            <div>
-              Runtime Health: <code className="font-mono">{runtimeHealth}</code>
             </div>
           </div>
         </div>
@@ -319,14 +312,17 @@ const DebugPanel: React.FC<DebugPanelProps> = ({
 };
 
 function DebugPin() {
-  const firstItem = useQuery(queryDb(tables.debug.select()));
+  const debugVersion = useQuery(
+    queryDb(
+      tables.debug.select("version").first({
+        fallback: () => {
+          return "unknown";
+        },
+      })
+    )
+  );
   return (
-    <div className="font-mono text-xs">
-      Debug Pin Version: {!firstItem && "NONE"}
-      {firstItem.length === 0 && "EMPTY"}
-      {/* If using VSCode, updating the schema doesn't automatically update the types in VSCode. Open command palette and run "TypeScript: Restart TS Server" */}
-      {firstItem.length > 0 && firstItem.map((item) => item.version).join(", ")}
-    </div>
+    <div className="font-mono text-xs">Debug Pin Version: {debugVersion}</div>
   );
 }
 

--- a/src/components/notebook/NotebookViewer.tsx
+++ b/src/components/notebook/NotebookViewer.tsx
@@ -11,8 +11,6 @@ import { Avatar } from "@/components/ui/Avatar.js";
 import { Button } from "@/components/ui/button";
 
 import { useAuth } from "@/components/auth/AuthProvider.js";
-import { useRuntimeHealth } from "@/hooks/useRuntimeHealth.js";
-import { useCurrentUserId } from "@/hooks/useCurrentUser.js";
 import { useUserRegistry } from "@/hooks/useUserRegistry.js";
 
 import { getClientColor, getClientTypeInfo } from "@/services/userTypes.js";

--- a/src/components/notebook/NotebookViewer.tsx
+++ b/src/components/notebook/NotebookViewer.tsx
@@ -12,11 +12,11 @@ import { Button } from "@/components/ui/button";
 
 import { useAuth } from "@/components/auth/AuthProvider.js";
 import { useRuntimeHealth } from "@/hooks/useRuntimeHealth.js";
+import { useCurrentUserId } from "@/hooks/useCurrentUser.js";
 import { useUserRegistry } from "@/hooks/useUserRegistry.js";
 
 import { getClientColor, getClientTypeInfo } from "@/services/userTypes.js";
 import { getDefaultAiModel, useAvailableAiModels } from "@/util/ai-models.js";
-import { getCurrentNotebookId } from "@/util/store-id.js";
 import { Bug, BugOff, Filter, Terminal, X } from "lucide-react";
 import { UserProfile } from "../auth/UserProfile.js";
 import { RuntimeHealthIndicator } from "./RuntimeHealthIndicator.js";
@@ -51,7 +51,6 @@ export const NotebookViewer: React.FC<NotebookViewerProps> = ({
   } = useAuth();
   const { presentUsers, getUserInfo, getUserColor } = useUserRegistry();
   const { models } = useAvailableAiModels();
-  const { runtimeHealth } = useRuntimeHealth();
 
   const cells = useQuery(
     queryDb(tables.cells.select().orderBy("position", "asc"))
@@ -78,12 +77,6 @@ export const NotebookViewer: React.FC<NotebookViewerProps> = ({
   const runtimeSessions = useQuery(
     queryDb(tables.runtimeSessions.select().where({ isActive: true }))
   );
-  // Get all runtime sessions for debug panel
-  const allRuntimeSessions = useQuery(queryDb(tables.runtimeSessions.select()));
-  // Get execution queue for debug panel
-  const executionQueue = useQuery(
-    queryDb(tables.executionQueue.select().orderBy("id", "desc"))
-  ) as any[];
 
   const [showRuntimeHelper, setShowRuntimeHelper] = React.useState(false);
   const [focusedCellId, setFocusedCellId] = React.useState<string | null>(null);
@@ -525,14 +518,7 @@ export const NotebookViewer: React.FC<NotebookViewerProps> = ({
             }
           >
             <ErrorBoundary fallback={<div>Error rendering debug panel</div>}>
-              <LazyDebugPanel
-                metadata={metadata}
-                cells={cells}
-                allRuntimeSessions={allRuntimeSessions}
-                executionQueue={executionQueue}
-                currentNotebookId={getCurrentNotebookId()}
-                runtimeHealth={runtimeHealth}
-              />
+              <LazyDebugPanel />
             </ErrorBoundary>
           </Suspense>
         )}

--- a/src/components/notebook/cell/AiCell.tsx
+++ b/src/components/notebook/cell/AiCell.tsx
@@ -314,7 +314,8 @@ export const AiCell: React.FC<AiCellProps> = ({
         </div>
 
         <CellControls
-          cell={cell}
+          sourceVisible={cell.sourceVisible}
+          aiContextVisible={cell.aiContextVisible}
           contextSelectionMode={contextSelectionMode}
           onMoveUp={onMoveUp}
           onMoveDown={onMoveDown}

--- a/src/components/notebook/cell/AiCell.tsx
+++ b/src/components/notebook/cell/AiCell.tsx
@@ -326,7 +326,8 @@ export const AiCell: React.FC<AiCellProps> = ({
           toggleAiContextVisibility={toggleAiContextVisibility}
           playButton={
             <PlayButton
-              cell={cell}
+              executionState={cell.executionState}
+              cellType={cell.cellType}
               autoFocus={autoFocus}
               onExecute={executeAiPrompt}
               onInterrupt={interruptAiCell}
@@ -347,7 +348,8 @@ export const AiCell: React.FC<AiCellProps> = ({
           }}
         >
           <PlayButton
-            cell={cell}
+            executionState={cell.executionState}
+            cellType={cell.cellType}
             autoFocus={autoFocus}
             onExecute={executeAiPrompt}
             onInterrupt={interruptAiCell}

--- a/src/components/notebook/cell/CodeCell.tsx
+++ b/src/components/notebook/cell/CodeCell.tsx
@@ -248,7 +248,8 @@ export const CodeCell: React.FC<CodeCellProps> = ({
         </div>
 
         <CellControls
-          cell={cell}
+          sourceVisible={cell.sourceVisible}
+          aiContextVisible={cell.aiContextVisible}
           contextSelectionMode={contextSelectionMode}
           onMoveUp={onMoveUp}
           onMoveDown={onMoveDown}

--- a/src/components/notebook/cell/CodeCell.tsx
+++ b/src/components/notebook/cell/CodeCell.tsx
@@ -260,7 +260,8 @@ export const CodeCell: React.FC<CodeCellProps> = ({
           toggleAiContextVisibility={toggleAiContextVisibility}
           playButton={
             <PlayButton
-              cell={cell}
+              executionState={cell.executionState}
+              cellType={cell.cellType}
               autoFocus={autoFocus}
               onExecute={executeCell}
               onInterrupt={interruptCell}
@@ -281,7 +282,8 @@ export const CodeCell: React.FC<CodeCellProps> = ({
           }}
         >
           <PlayButton
-            cell={cell}
+            executionState={cell.executionState}
+            cellType={cell.cellType}
             autoFocus={autoFocus}
             onExecute={executeCell}
             onInterrupt={interruptCell}

--- a/src/components/notebook/cell/MarkdownCell.tsx
+++ b/src/components/notebook/cell/MarkdownCell.tsx
@@ -232,7 +232,8 @@ export const MarkdownCell: React.FC<MarkdownCellProps> = ({
         </div>
 
         <CellControls
-          cell={cell}
+          sourceVisible={cell.sourceVisible}
+          aiContextVisible={cell.aiContextVisible}
           contextSelectionMode={contextSelectionMode}
           onMoveUp={onMoveUp}
           onMoveDown={onMoveDown}

--- a/src/components/notebook/cell/SqlCell.tsx
+++ b/src/components/notebook/cell/SqlCell.tsx
@@ -224,7 +224,8 @@ export const SqlCell: React.FC<SqlCellProps> = ({
         </div>
 
         <CellControls
-          cell={cell}
+          sourceVisible={cell.sourceVisible}
+          aiContextVisible={cell.aiContextVisible}
           contextSelectionMode={contextSelectionMode}
           onMoveUp={onMoveUp}
           onMoveDown={onMoveDown}

--- a/src/components/notebook/cell/SqlCell.tsx
+++ b/src/components/notebook/cell/SqlCell.tsx
@@ -236,7 +236,8 @@ export const SqlCell: React.FC<SqlCellProps> = ({
           toggleAiContextVisibility={toggleAiContextVisibility}
           playButton={
             <PlayButton
-              cell={cell}
+              executionState={cell.executionState}
+              cellType={cell.cellType}
               autoFocus={autoFocus}
               onExecute={executeQuery}
               onInterrupt={interruptQuery}
@@ -257,7 +258,8 @@ export const SqlCell: React.FC<SqlCellProps> = ({
           }}
         >
           <PlayButton
-            cell={cell}
+            executionState={cell.executionState}
+            cellType={cell.cellType}
             autoFocus={autoFocus}
             onExecute={executeQuery}
             onInterrupt={interruptQuery}

--- a/src/components/notebook/cell/shared/CellControls.tsx
+++ b/src/components/notebook/cell/shared/CellControls.tsx
@@ -17,10 +17,10 @@ import {
   MoreVertical,
   Eraser,
 } from "lucide-react";
-import { tables } from "@runt/schema";
 
 interface CellControlsProps {
-  cell: typeof tables.cells.Type;
+  sourceVisible: boolean;
+  aiContextVisible: boolean;
   contextSelectionMode?: boolean;
   onMoveUp: () => void;
   onMoveDown: () => void;
@@ -33,7 +33,8 @@ interface CellControlsProps {
 }
 
 export const CellControls: React.FC<CellControlsProps> = ({
-  cell,
+  sourceVisible,
+  aiContextVisible,
   contextSelectionMode = false,
   onMoveUp,
   onMoveDown,
@@ -55,11 +56,11 @@ export const CellControls: React.FC<CellControlsProps> = ({
         size="sm"
         onClick={toggleSourceVisibility}
         className={`hover:bg-muted/80 h-8 w-8 p-0 sm:h-7 sm:w-7 ${
-          cell.sourceVisible ? "" : "text-muted-foreground/60"
+          sourceVisible ? "" : "text-muted-foreground/60"
         }`}
-        title={cell.sourceVisible ? "Hide source" : "Show source"}
+        title={sourceVisible ? "Hide source" : "Show source"}
       >
-        {cell.sourceVisible ? (
+        {sourceVisible ? (
           <ChevronUp className="h-4 w-4 sm:h-3 sm:w-3" />
         ) : (
           <ChevronDown className="h-4 w-4 sm:h-3 sm:w-3" />
@@ -73,15 +74,13 @@ export const CellControls: React.FC<CellControlsProps> = ({
           size="sm"
           onClick={toggleAiContextVisibility}
           className={`hover:bg-muted/80 h-8 w-8 p-0 sm:h-7 sm:w-7 ${
-            cell.aiContextVisible ? "text-purple-600" : "text-gray-500"
+            aiContextVisible ? "text-purple-600" : "text-gray-500"
           }`}
           title={
-            cell.aiContextVisible
-              ? "Hide from AI context"
-              : "Show in AI context"
+            aiContextVisible ? "Hide from AI context" : "Show in AI context"
           }
         >
-          {cell.aiContextVisible ? (
+          {aiContextVisible ? (
             <Eye className="h-4 w-4 sm:h-3 sm:w-3" />
           ) : (
             <EyeOff className="h-4 w-4 sm:h-3 sm:w-3" />

--- a/src/components/notebook/cell/shared/PlayButton.tsx
+++ b/src/components/notebook/cell/shared/PlayButton.tsx
@@ -1,10 +1,10 @@
 import React from "react";
 import { Button } from "@/components/ui/button";
 import { Square, Play } from "lucide-react";
-import { tables } from "@runt/schema";
 
 interface PlayButtonProps {
-  cell: typeof tables.cells.Type;
+  executionState: "idle" | "queued" | "running" | "completed" | "error";
+  cellType: string;
   autoFocus?: boolean;
   onExecute: () => void;
   onInterrupt: () => void;
@@ -14,7 +14,8 @@ interface PlayButtonProps {
 }
 
 export const PlayButton: React.FC<PlayButtonProps> = ({
-  cell,
+  executionState,
+  cellType,
   autoFocus = false,
   onExecute,
   onInterrupt,
@@ -22,21 +23,20 @@ export const PlayButton: React.FC<PlayButtonProps> = ({
   size = "sm",
   primaryColor = "text-foreground",
 }) => {
-  const isRunning =
-    cell.executionState === "running" || cell.executionState === "queued";
+  const isRunning = executionState === "running" || executionState === "queued";
 
   const getExecuteTitle = () => {
-    if (cell.executionState === "running" || cell.executionState === "queued") {
+    if (executionState === "running" || executionState === "queued") {
       return "Stop execution";
     }
-    return `Execute ${cell.cellType} cell`;
+    return `Execute ${cellType} cell`;
   };
 
   const getPlayButtonContent = () => {
-    if (cell.executionState === "running") {
+    if (executionState === "running") {
       return <Square className="h-3 w-3" />;
     }
-    if (cell.executionState === "queued") {
+    if (executionState === "queued") {
       return <Square className="h-3 w-3" />;
     }
     return <Play className="h-4 w-4" />;

--- a/src/queries/index.ts
+++ b/src/queries/index.ts
@@ -1,0 +1,46 @@
+import { tables } from "@runt/schema";
+import { queryDb } from "@livestore/livestore";
+
+export * from "./outputDeltas";
+
+export const cellIDs$ = queryDb(
+  tables.cells.select("id").orderBy("position", "asc"),
+  { label: "notebook.cellIds" }
+);
+
+export const notebookMetadata$ = queryDb(
+  tables.notebookMetadata.select("key", "value")
+);
+
+export const cellQuery = {
+  byId: (cellId: string) =>
+    queryDb(
+      tables.cells
+        .select()
+        .where({ id: cellId })
+        .first({
+          fallback: () => null,
+        }),
+      {
+        deps: [cellId],
+        label: `cell.${cellId}`,
+      }
+    ),
+
+  outputs: (cellId: string) =>
+    queryDb(
+      tables.outputs.select().where({ cellId }).orderBy("position", "asc"),
+      { deps: [cellId], label: `outputs:${cellId}` }
+    ),
+
+  executionQueue: (cellId: string) =>
+    queryDb(
+      tables.executionQueue.select().where({ cellId }).orderBy("id", "desc"),
+      { deps: [cellId], label: `queue:${cellId}` }
+    ),
+};
+
+export const runtimeSessions$ = queryDb(
+  tables.runtimeSessions.select().orderBy("sessionId", "desc"),
+  { label: "runtime.sessions" }
+);


### PR DESCRIPTION
This establishes `src/queries/index.ts` to have common `queryDb` calls we use with `useQuery`.

The long term goal is to switch all queries to idiomatic React(ive) usage. For now, this just cleans up the debug panel to only have its queries running when open instead of always passing down data from the parent. Way less running now when the debug panel is closed:

https://github.com/user-attachments/assets/656cd850-82de-4197-b366-607d2200e9b3

