### PR TITLE
bump runt version

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@radix-ui/react-separator": "^1.1.7",
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-tooltip": "^1.1.6",
-    "@runt/schema": "github:runtimed/runt#03dab62e0b1f7527cf7ffa623bbc50664ff180be&path:/packages/schema",
+    "@runt/schema": "github:runtimed/runt#25d7d6e071da3606be9f6d47d0621dfe3856a9de&path:/packages/schema",
     "@tanstack/react-virtual": "^3.13.12",
     "@types/react-syntax-highlighter": "^15.5.13",
     "@uiw/codemirror-theme-github": "^4.23.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,8 +86,8 @@ importers:
         specifier: ^1.1.6
         version: 1.2.7(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@runt/schema':
-        specifier: github:runtimed/runt#03dab62e0b1f7527cf7ffa623bbc50664ff180be&path:/packages/schema
-        version: https://codeload.github.com/runtimed/runt/tar.gz/03dab62e0b1f7527cf7ffa623bbc50664ff180be#path:/packages/schema(f9c23af240f2640c0a9abef8711d3cc6)
+        specifier: github:runtimed/runt#25d7d6e071da3606be9f6d47d0621dfe3856a9de&path:/packages/schema
+        version: https://codeload.github.com/runtimed/runt/tar.gz/25d7d6e071da3606be9f6d47d0621dfe3856a9de#path:/packages/schema(f9c23af240f2640c0a9abef8711d3cc6)
       '@tanstack/react-virtual':
         specifier: ^3.13.12
         version: 3.13.12(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -1854,8 +1854,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@runt/schema@https://codeload.github.com/runtimed/runt/tar.gz/03dab62e0b1f7527cf7ffa623bbc50664ff180be#path:/packages/schema':
-    resolution: {path: /packages/schema, tarball: https://codeload.github.com/runtimed/runt/tar.gz/03dab62e0b1f7527cf7ffa623bbc50664ff180be}
+  '@runt/schema@https://codeload.github.com/runtimed/runt/tar.gz/25d7d6e071da3606be9f6d47d0621dfe3856a9de#path:/packages/schema':
+    resolution: {path: /packages/schema, tarball: https://codeload.github.com/runtimed/runt/tar.gz/25d7d6e071da3606be9f6d47d0621dfe3856a9de}
     version: 0.8.0
 
   '@sindresorhus/is@7.0.2':
@@ -6278,7 +6278,7 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.45.0':
     optional: true
 
-  '@runt/schema@https://codeload.github.com/runtimed/runt/tar.gz/03dab62e0b1f7527cf7ffa623bbc50664ff180be#path:/packages/schema(f9c23af240f2640c0a9abef8711d3cc6)':
+  '@runt/schema@https://codeload.github.com/runtimed/runt/tar.gz/25d7d6e071da3606be9f6d47d0621dfe3856a9de#path:/packages/schema(f9c23af240f2640c0a9abef8711d3cc6)':
     dependencies:
       '@livestore/livestore': 0.3.1(f9c23af240f2640c0a9abef8711d3cc6)
     transitivePeerDependencies:


### PR DESCRIPTION
Bringing us up to `main` from runt at `25d7d6e071da3606be9f6d47d0621dfe3856a9de`.

Diff: https://github.com/runtimed/runt/compare/03dab62e0b1f7527cf7ffa623bbc50664ff180be...25d7d6e071da3606be9f6d47d0621dfe3856a9de