### PR TITLE
Remove artificial loading delays for faster startup

### DIFF
--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -84,7 +84,6 @@ const AnimatedLiveStoreApp: React.FC = () => {
   const [showIncomingAnimation, setShowIncomingAnimation] = useState(false);
   const [animationComplete, setAnimationComplete] = useState(false);
   const [liveStoreReady, setLiveStoreReady] = useState(false);
-  const [minimumTimeElapsed, setMinimumTimeElapsed] = useState(false);
   const [portalAnimationComplete, setPortalAnimationComplete] = useState(false);
   const [portalReady, setPortalReady] = useState(false);
 
@@ -95,44 +94,33 @@ const AnimatedLiveStoreApp: React.FC = () => {
     }
   }, [liveStoreReady]);
 
-  // Ensure minimum loading time (so users see the progressive loading)
+  // Trigger animation when LiveStore is ready
   useEffect(() => {
-    const minimumLoadingTimer = setTimeout(() => {
-      setMinimumTimeElapsed(true);
-    }, 2500); // Minimum 2.5 seconds to appreciate the loading
-
-    return () => clearTimeout(minimumLoadingTimer);
-  }, []);
-
-  // Trigger animation when both LiveStore is ready AND minimum time elapsed
-  useEffect(() => {
-    if (liveStoreReady && minimumTimeElapsed && isLoading) {
+    if (liveStoreReady && isLoading) {
       updateLoadingStage("ready");
 
-      // Small delay to let user see the final stage, then remove static screen
+      // Remove static screen and start React animation immediately
+      removeStaticLoadingScreen();
+      setShowIncomingAnimation(true);
+
+      // Give React component a moment to mount, then trigger animation
       setTimeout(() => {
-        removeStaticLoadingScreen();
-        setShowIncomingAnimation(true);
+        setPortalReady(true);
+      }, 50); // Minimal delay for React mounting
 
-        // Give React component a moment to mount, then trigger animation
-        setTimeout(() => {
-          setPortalReady(true);
-        }, 100);
-      }, 300);
-
-      // Wait for portal animation to complete (expansion + shrink to dot)
+      // Wait for actual portal animation duration (from NotebookLoadingScreen)
       setTimeout(() => {
         setPortalAnimationComplete(true);
-      }, 2500); // Time for full portal sequence + removal delay
+      }, 1500); // Actual portal animation time: 1200ms + 300ms buffer
     }
-  }, [liveStoreReady, minimumTimeElapsed, isLoading]);
+  }, [liveStoreReady, isLoading]);
 
   // Complete transition only after portal animation finishes
   useEffect(() => {
     if (portalAnimationComplete && showIncomingAnimation) {
       setIsLoading(false);
       // Allow time for header animation to complete
-      setTimeout(() => setAnimationComplete(true), 1500);
+      setTimeout(() => setAnimationComplete(true), 500); // Reduced from 1500ms
     }
   }, [portalAnimationComplete, showIncomingAnimation]);
 


### PR DESCRIPTION
Removes artificial timing delays that were slowing down the loading experience unnecessarily.

## Changes
- **Eliminate 2.5 second minimum loading time** - was purely cosmetic
- **Remove 300ms delay** before removing static screen  
- **Reduce React mounting delay** from 100ms to 50ms
- **Use actual animation duration** (1200ms + 300ms buffer) instead of arbitrary 2.5s
- **Reduce final transition delay** from 1500ms to 500ms

## Result
Loading now happens as fast as LiveStore is ready rather than forcing users to wait for arbitrary timers. On fast connections, the app loads significantly faster while still preserving all animations and smooth transitions.

The seamless loading experience remains intact - we just removed the artificial speed bumps.