### PR TITLE
Fix auth flow getting stuck at 'Checking Authentication'

### DIFF
--- a/src/components/auth/AuthGuard.tsx
+++ b/src/components/auth/AuthGuard.tsx
@@ -1,7 +1,10 @@
 import React, { useEffect, useState } from "react";
 import { useAuth } from "./AuthProvider.js";
 import LoginPrompt from "./LoginPrompt.js";
-import { updateLoadingStage } from "../../util/domUpdates.js";
+import {
+  updateLoadingStage,
+  removeStaticLoadingScreen,
+} from "../../util/domUpdates.js";
 
 interface AuthGuardProps {
   children: React.ReactNode;
@@ -20,6 +23,7 @@ export const AuthGuard: React.FC<AuthGuardProps> = ({ children, fallback }) => {
   // Update loading stage when auth check starts
   useEffect(() => {
     if (isLoading) {
+      console.log("🔐 AuthGuard: Starting auth check");
       updateLoadingStage("checking-auth");
     }
   }, [isLoading]);
@@ -36,6 +40,14 @@ export const AuthGuard: React.FC<AuthGuardProps> = ({ children, fallback }) => {
     return () => window.removeEventListener("message", handleMessage);
   }, []);
 
+  // Remove static loading screen when auth check completes
+  useEffect(() => {
+    if (!isLoading) {
+      console.log("🔐 AuthGuard: Auth check complete, removing static screen");
+      removeStaticLoadingScreen();
+    }
+  }, [isLoading]);
+
   // Show transparent loading state - let static HTML loading screen handle UI
   if (isLoading) {
     return null;
@@ -43,6 +55,10 @@ export const AuthGuard: React.FC<AuthGuardProps> = ({ children, fallback }) => {
 
   // Show error state if authentication failed or auth expired
   if ((error && !isAuthenticated) || authExpiredError) {
+    console.log("🔐 AuthGuard: Showing error state", {
+      error,
+      authExpiredError,
+    });
     return (
       <div className="bg-background flex min-h-screen items-center justify-center">
         <div className="max-w-md text-center">
@@ -76,6 +92,7 @@ export const AuthGuard: React.FC<AuthGuardProps> = ({ children, fallback }) => {
 
   // Show sign-in form if not authenticated
   if (!isAuthenticated) {
+    console.log("🔐 AuthGuard: Showing login form");
     return (
       fallback || (
         <div className="bg-background flex min-h-screen items-center justify-center">
@@ -102,5 +119,6 @@ export const AuthGuard: React.FC<AuthGuardProps> = ({ children, fallback }) => {
   }
 
   // Show authenticated content
+  console.log("🔐 AuthGuard: User authenticated, showing app");
   return <>{children}</>;
 };

--- a/src/components/auth/AuthGuard.tsx
+++ b/src/components/auth/AuthGuard.tsx
@@ -23,7 +23,6 @@ export const AuthGuard: React.FC<AuthGuardProps> = ({ children, fallback }) => {
   // Update loading stage when auth check starts
   useEffect(() => {
     if (isLoading) {
-      console.log("🔐 AuthGuard: Starting auth check");
       updateLoadingStage("checking-auth");
     }
   }, [isLoading]);
@@ -43,7 +42,6 @@ export const AuthGuard: React.FC<AuthGuardProps> = ({ children, fallback }) => {
   // Remove static loading screen when auth check completes
   useEffect(() => {
     if (!isLoading) {
-      console.log("🔐 AuthGuard: Auth check complete, removing static screen");
       removeStaticLoadingScreen();
     }
   }, [isLoading]);
@@ -55,10 +53,6 @@ export const AuthGuard: React.FC<AuthGuardProps> = ({ children, fallback }) => {
 
   // Show error state if authentication failed or auth expired
   if ((error && !isAuthenticated) || authExpiredError) {
-    console.log("🔐 AuthGuard: Showing error state", {
-      error,
-      authExpiredError,
-    });
     return (
       <div className="bg-background flex min-h-screen items-center justify-center">
         <div className="max-w-md text-center">
@@ -92,7 +86,6 @@ export const AuthGuard: React.FC<AuthGuardProps> = ({ children, fallback }) => {
 
   // Show sign-in form if not authenticated
   if (!isAuthenticated) {
-    console.log("🔐 AuthGuard: Showing login form");
     return (
       fallback || (
         <div className="bg-background flex min-h-screen items-center justify-center">
@@ -119,6 +112,5 @@ export const AuthGuard: React.FC<AuthGuardProps> = ({ children, fallback }) => {
   }
 
   // Show authenticated content
-  console.log("🔐 AuthGuard: User authenticated, showing app");
   return <>{children}</>;
 };


### PR DESCRIPTION
Critical fix for auth flow regression introduced by seamless loading changes.

## Problem
Users getting stuck at "Checking Authentication..." screen when auth fails or login is required. The static loading screen never gets removed, preventing access to login form.

## Root Cause  
When we made AuthGuard transparent during loading (return `null`), we removed the logic that handles transitioning away from the loading state when auth fails.

## Solution
- **Remove static loading screen** when auth check completes (regardless of success/failure)
- **Ensure login screen shows** properly when auth fails