### PR TITLE
Fix TypeScript config to include vite-plugins directory

### DIFF
--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -7,5 +7,5 @@
     "allowSyntheticDefaultImports": true,
     "strict": true
   },
-  "include": ["vite.config.ts"]
+  "include": ["vite.config.ts", "vite-plugins/**/*.ts"]
 }


### PR DESCRIPTION
Add vite-plugins/**/*.ts to tsconfig.node.json include patterns to resolve: 'File is not listed within the file list of project' error