### PR TITLE
Fix OIDC route stuck at 'Initializing...' loading screen

### DIFF
--- a/src/components/auth/AuthRedirect.tsx
+++ b/src/components/auth/AuthRedirect.tsx
@@ -9,6 +9,10 @@ import {
   CardHeader,
   CardTitle,
 } from "../ui/card";
+import {
+  updateLoadingStage,
+  removeStaticLoadingScreen,
+} from "../../util/domUpdates";
 
 const AuthRedirect: React.FC = () => {
   const openIdService = getOpenIdService();
@@ -16,6 +20,10 @@ const AuthRedirect: React.FC = () => {
   const navigate = useNavigate();
 
   useEffect(() => {
+    // Remove the static loading screen so our component UI is visible
+    updateLoadingStage("checking-auth");
+    removeStaticLoadingScreen();
+
     const subscription = openIdService.handleRedirect().subscribe({
       complete: () => {
         navigate("/", { replace: true });


### PR DESCRIPTION
The OIDC callback route was showing the static loading screen overlay with "Initializing..." instead of the AuthRedirect component's "Logging in..." UI. This PR removes the static overlay when the AuthRedirect component mounts, allowing users to see the proper authentication flow UI.