### PR TITLE
Fix body overflow scroll

### DIFF
--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -125,20 +125,6 @@ const AnimatedLiveStoreApp: React.FC = () => {
     }
   }, [portalAnimationComplete, showIncomingAnimation]);
 
-  // Ensure body overflow is reset when app loads
-  useEffect(() => {
-    // Reset overflow in case it was left from previous sessions
-    if (!isLoading) {
-      document.body.style.overflow = "";
-      document.body.classList.add("app-loaded");
-    }
-
-    // Always reset on unmount to prevent stuck state
-    return () => {
-      document.body.style.overflow = "";
-    };
-  }, [isLoading]);
-
   return (
     <>
       {/* Loading screen overlay - fixed position to prevent layout shift */}

--- a/vite-plugins/inject-loading-screen.ts
+++ b/vite-plugins/inject-loading-screen.ts
@@ -120,11 +120,6 @@ export function injectLoadingScreen(): Plugin {
               font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
               margin: 0;
               padding: 0;
-              overflow: hidden;
-            }
-            /* Remove overflow hidden after React app loads */
-            body.app-loaded {
-              overflow: auto !important;
             }
             /* Import existing pixel-logo and rune-throb styles */
             .pixel-logo {
@@ -173,38 +168,6 @@ export function injectLoadingScreen(): Plugin {
 
         // Add loading screen immediately after body opens
         modifiedHtml = modifiedHtml.replace("<body>", `<body>${loadingHTML}`);
-
-        // Add script to reset body overflow when app loads
-        const cleanupScript = `
-          <script>
-            // Reset body overflow when React app takes over
-            window.addEventListener('DOMContentLoaded', function() {
-              // Watch for when the loading screen is removed
-              const observer = new MutationObserver(function(mutations) {
-                const loadingScreen = document.getElementById('static-loading-screen');
-                if (!loadingScreen || loadingScreen.style.display === 'none') {
-                  document.body.style.overflow = '';
-                  document.body.classList.add('app-loaded');
-                  observer.disconnect();
-                }
-              });
-
-              observer.observe(document.body, { childList: true, subtree: true });
-
-              // Fallback: ensure overflow is reset after 5 seconds
-              setTimeout(function() {
-                document.body.style.overflow = '';
-                document.body.classList.add('app-loaded');
-              }, 5000);
-            });
-          </script>
-        `;
-
-        // Add cleanup script before closing body tag
-        modifiedHtml = modifiedHtml.replace(
-          "</body>",
-          `${cleanupScript}</body>`
-        );
 
         return modifiedHtml;
       },


### PR DESCRIPTION
While trying to make sure that an animation stayed consistent from early start to initial load to auth to loading livestore, I had added this `overflow: hidden` to the body that either needed to be rigorously removed _or_ just not be there at all since the loading screen uses a fixed position with inset-0.