### PR TITLE
 Implement declarative code splitting with dynamic imports

### DIFF
--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -128,11 +128,6 @@ const AnimatedLiveStoreApp: React.FC = () => {
           removeStaticLoadingScreen();
           setShowIncomingAnimation(true);
           setPortalReady(true);
-
-          // Wait for actual portal animation duration (from NotebookLoadingScreen)
-          setTimeout(() => {
-            setPortalAnimationComplete(true);
-          }, 1500); // Actual portal animation time: 1200ms + 300ms buffer
         });
       });
     }

--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -5,7 +5,6 @@ import { LiveStoreProvider } from "@livestore/react";
 import React, { useEffect, useState, useRef, Suspense } from "react";
 import {
   LoadingState,
-  InlineLoading,
   MinimalLoading,
 } from "./components/loading/LoadingState.js";
 import { Routes, Route } from "react-router-dom";

--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -86,7 +86,7 @@ const NotebookApp: React.FC<NotebookAppProps> = ({
       )}
       {/* Main Content */}
       <ErrorBoundary fallback={<div>Error loading notebook</div>}>
-        <Suspense fallback={null}>
+        <Suspense fallback={<div className="min-h-screen bg-white" />}>
           <NotebookViewer
             notebookId={currentNotebookId}
             debugMode={debugMode}
@@ -121,19 +121,24 @@ const AnimatedLiveStoreApp: React.FC = () => {
     if (liveStoreReady && isLoading) {
       updateLoadingStage("ready");
 
-      // Remove static screen and start React animation immediately
-      removeStaticLoadingScreen();
-      setShowIncomingAnimation(true);
+      // Ensure React has painted before removing static screen
+      requestAnimationFrame(() => {
+        // Double RAF to ensure paint has completed
+        requestAnimationFrame(() => {
+          removeStaticLoadingScreen();
+          setShowIncomingAnimation(true);
 
-      // Give React component a moment to mount, then trigger animation
-      setTimeout(() => {
-        setPortalReady(true);
-      }, 50); // Minimal delay for React mounting
+          // Give React component a moment to mount, then trigger animation
+          setTimeout(() => {
+            setPortalReady(true);
+          }, 50); // Minimal delay for React mounting
 
-      // Wait for actual portal animation duration (from NotebookLoadingScreen)
-      setTimeout(() => {
-        setPortalAnimationComplete(true);
-      }, 1500); // Actual portal animation time: 1200ms + 300ms buffer
+          // Wait for actual portal animation duration (from NotebookLoadingScreen)
+          setTimeout(() => {
+            setPortalAnimationComplete(true);
+          }, 1500); // Actual portal animation time: 1200ms + 300ms buffer
+        });
+      });
     }
   }, [liveStoreReady, isLoading]);
 
@@ -151,7 +156,7 @@ const AnimatedLiveStoreApp: React.FC = () => {
       {/* Loading screen overlay - fixed position to prevent layout shift */}
       {isLoading && (
         <div className="fixed inset-0 z-50 overflow-hidden">
-          <Suspense fallback={null}>
+          <Suspense fallback={<div className="min-h-screen bg-white" />}>
             <NotebookLoadingScreen
               ready={portalReady}
               onPortalAnimationComplete={() => setPortalAnimationComplete(true)}

--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -86,7 +86,7 @@ const NotebookApp: React.FC<NotebookAppProps> = ({
       )}
       {/* Main Content */}
       <ErrorBoundary fallback={<div>Error loading notebook</div>}>
-        <Suspense fallback={<InlineLoading message="Loading notebook..." />}>
+        <Suspense fallback={null}>
           <NotebookViewer
             notebookId={currentNotebookId}
             debugMode={debugMode}
@@ -151,7 +151,7 @@ const AnimatedLiveStoreApp: React.FC = () => {
       {/* Loading screen overlay - fixed position to prevent layout shift */}
       {isLoading && (
         <div className="fixed inset-0 z-50 overflow-hidden">
-          <Suspense fallback={<LoadingState variant="fullscreen" animated />}>
+          <Suspense fallback={null}>
             <NotebookLoadingScreen
               ready={portalReady}
               onPortalAnimationComplete={() => setPortalAnimationComplete(true)}

--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -127,11 +127,7 @@ const AnimatedLiveStoreApp: React.FC = () => {
         requestAnimationFrame(() => {
           removeStaticLoadingScreen();
           setShowIncomingAnimation(true);
-
-          // Give React component a moment to mount, then trigger animation
-          setTimeout(() => {
-            setPortalReady(true);
-          }, 50); // Minimal delay for React mounting
+          setPortalReady(true);
 
           // Wait for actual portal animation duration (from NotebookLoadingScreen)
           setTimeout(() => {

--- a/src/components/auth/AuthGuard.tsx
+++ b/src/components/auth/AuthGuard.tsx
@@ -45,12 +45,8 @@ export const AuthGuard: React.FC<AuthGuardProps> = ({ children, fallback }) => {
     return () => window.removeEventListener("message", handleMessage);
   }, []);
 
-  // Remove static loading screen when auth check completes
-  useEffect(() => {
-    if (!isLoading) {
-      removeStaticLoadingScreen();
-    }
-  }, [isLoading]);
+  // Don't remove static loading screen here - let AnimatedLiveStoreApp handle it
+  // to prevent white flicker between auth and notebook loading
 
   // Show transparent loading state - let static HTML loading screen handle UI
   if (isLoading) {

--- a/src/components/auth/AuthGuard.tsx
+++ b/src/components/auth/AuthGuard.tsx
@@ -1,10 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { useAuth } from "./AuthProvider.js";
 import LoginPrompt from "./LoginPrompt.js";
-import {
-  updateLoadingStage,
-  removeStaticLoadingScreen,
-} from "../../util/domUpdates.js";
+import { updateLoadingStage } from "../../util/domUpdates.js";
 import { RuntLogo } from "../logo";
 
 // DEV MODE: Force login screen for design testing

--- a/src/components/loading/LoadingState.tsx
+++ b/src/components/loading/LoadingState.tsx
@@ -36,9 +36,7 @@ export const LoadingState: React.FC<LoadingStateProps> = ({
             animation={animated ? "animate-pulse" : ""}
           />
           {message && (
-            <div className="text-lg font-semibold text-gray-700">
-              {message}
-            </div>
+            <div className="text-lg font-semibold text-gray-700">{message}</div>
           )}
         </div>
       </div>
@@ -50,7 +48,7 @@ export const LoadingState: React.FC<LoadingStateProps> = ({
       <div className={`flex items-center justify-center p-4 ${className}`}>
         <RuntLogo size="h-8 w-8" animated={false} className="opacity-50" />
         {message && (
-          <span className="ml-2 text-sm text-muted-foreground">{message}</span>
+          <span className="text-muted-foreground ml-2 text-sm">{message}</span>
         )}
       </div>
     );
@@ -69,7 +67,7 @@ export const LoadingState: React.FC<LoadingStateProps> = ({
         animation={animated ? "animate-pulse" : ""}
       />
       {message && (
-        <div className="text-sm text-muted-foreground animate-pulse">
+        <div className="text-muted-foreground animate-pulse text-sm">
           {message}
         </div>
       )}
@@ -86,6 +84,6 @@ export const InlineLoading: React.FC<{ message?: string }> = ({
   message = "Loading...",
 }) => <LoadingState variant="inline" message={message} />;
 
-export const MinimalLoading: React.FC<{ message?: string }> = ({
-  message,
-}) => <LoadingState variant="minimal" message={message} />;
+export const MinimalLoading: React.FC<{ message?: string }> = ({ message }) => (
+  <LoadingState variant="minimal" message={message} />
+);

--- a/src/components/loading/LoadingState.tsx
+++ b/src/components/loading/LoadingState.tsx
@@ -1,0 +1,91 @@
+import React from "react";
+import { RuntLogo } from "../logo/RuntLogo";
+
+interface LoadingStateProps {
+  /** Variant of the loading state */
+  variant?: "fullscreen" | "inline" | "minimal";
+  /** Optional loading message */
+  message?: string;
+  /** Additional CSS classes */
+  className?: string;
+  /** Whether to show the animated version */
+  animated?: boolean;
+}
+
+/**
+ * Reusable loading state component that uses the Runt logo
+ * Perfect for Suspense boundaries and loading states
+ */
+export const LoadingState: React.FC<LoadingStateProps> = ({
+  variant = "inline",
+  message,
+  className = "",
+  animated = true,
+}) => {
+  if (variant === "fullscreen") {
+    return (
+      <div
+        className={`flex min-h-screen items-center justify-center bg-white ${className}`}
+      >
+        <div className="text-center">
+          <RuntLogo
+            size="h-24 w-24 sm:h-32 sm:w-32"
+            animated={animated}
+            energized={false}
+            className="mx-auto mb-6"
+            animation={animated ? "animate-pulse" : ""}
+          />
+          {message && (
+            <div className="text-lg font-semibold text-gray-700">
+              {message}
+            </div>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  if (variant === "minimal") {
+    return (
+      <div className={`flex items-center justify-center p-4 ${className}`}>
+        <RuntLogo size="h-8 w-8" animated={false} className="opacity-50" />
+        {message && (
+          <span className="ml-2 text-sm text-muted-foreground">{message}</span>
+        )}
+      </div>
+    );
+  }
+
+  // Default "inline" variant
+  return (
+    <div
+      className={`flex flex-col items-center justify-center py-12 ${className}`}
+    >
+      <RuntLogo
+        size="h-16 w-16"
+        animated={animated}
+        energized={false}
+        className="mb-4"
+        animation={animated ? "animate-pulse" : ""}
+      />
+      {message && (
+        <div className="text-sm text-muted-foreground animate-pulse">
+          {message}
+        </div>
+      )}
+    </div>
+  );
+};
+
+// Export convenience components for common use cases
+export const FullscreenLoading: React.FC<{ message?: string }> = ({
+  message = "Loading...",
+}) => <LoadingState variant="fullscreen" message={message} />;
+
+export const InlineLoading: React.FC<{ message?: string }> = ({
+  message = "Loading...",
+}) => <LoadingState variant="inline" message={message} />;
+
+export const MinimalLoading: React.FC<{ message?: string }> = ({
+  message,
+}) => <LoadingState variant="minimal" message={message} />;

--- a/src/components/notebook/NotebookLoadingScreen.tsx
+++ b/src/components/notebook/NotebookLoadingScreen.tsx
@@ -44,6 +44,16 @@ export const NotebookLoadingScreen: React.FC<NotebookLoadingScreenProps> = ({
       }
     },
     config: { tension: 200, friction: 20 },
+    onRest: () => {
+      if (startAnimation) {
+        onPortalAnimationComplete?.();
+        // Small delay before final transition
+        setTimeout(() => {
+          setTransitioning(true);
+          onTransitionComplete?.();
+        }, 300);
+      }
+    },
   });
 
   const bracketSpring = useSpring({
@@ -75,19 +85,8 @@ export const NotebookLoadingScreen: React.FC<NotebookLoadingScreenProps> = ({
       setLoadingProgress(3);
       setStartAnimation(true);
       setFlyingOut(true);
-
-      // Portal animation completes first (expansion + shrink to dot)
-      setTimeout(() => {
-        onPortalAnimationComplete?.();
-      }, 1200);
-
-      // Complete transition after animation
-      setTimeout(() => {
-        setTransitioning(true);
-        onTransitionComplete?.();
-      }, 1500);
     }
-  }, [ready, startAnimation, onTransitionComplete, onPortalAnimationComplete]);
+  }, [ready, startAnimation]);
   if (transitioning) {
     return null; // Let header take over
   }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -54,27 +54,6 @@ export default defineConfig(({ mode }) => {
   return {
     build: {
       sourcemap: true,
-      rollupOptions: {
-        output: {
-          manualChunks: (id) => {
-            // Split markdown-related dependencies into their own chunk
-            if (
-              id.includes("react-markdown") ||
-              id.includes("remark-gfm") ||
-              id.includes("react-syntax-highlighter") ||
-              id.includes("prism") ||
-              id.includes("refractor") ||
-              id.includes("hastscript") ||
-              id.includes("hast-") ||
-              id.includes("mdast-") ||
-              id.includes("micromark") ||
-              id.includes("unist-")
-            ) {
-              return "markdown";
-            }
-          },
-        },
-      },
     },
     server: {
       port: env.ANODE_DEV_SERVER_PORT


### PR DESCRIPTION
Break up the routes into dynamic `import()`s, remove manual Vite chunking config, and clean up timers in loading animations. This reduces the initial bundle to 947KB, which when gzipped is ~292KB.