### PR TITLE
Refactor animation system to use React Spring chaining

### DIFF
--- a/src/components/notebook/NotebookLoadingScreen.tsx
+++ b/src/components/notebook/NotebookLoadingScreen.tsx
@@ -47,11 +47,8 @@ export const NotebookLoadingScreen: React.FC<NotebookLoadingScreenProps> = ({
     onRest: () => {
       if (startAnimation) {
         onPortalAnimationComplete?.();
-        // Small delay before final transition
-        setTimeout(() => {
-          setTransitioning(true);
-          onTransitionComplete?.();
-        }, 300);
+        setTransitioning(true);
+        onTransitionComplete?.();
       }
     },
   });

--- a/src/components/notebook/NotebookViewer.tsx
+++ b/src/components/notebook/NotebookViewer.tsx
@@ -1,7 +1,7 @@
 import { queryDb } from "@livestore/livestore";
 import { useQuery, useStore } from "@livestore/react";
 import { CellData, events, tables } from "@runt/schema";
-import React, { Suspense, useCallback, useState, useEffect } from "react";
+import React, { Suspense, useCallback } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 
 import { NotebookTitle } from "./NotebookTitle.js";
@@ -37,15 +37,11 @@ interface NotebookViewerProps {
   notebookId: string;
   debugMode?: boolean;
   onDebugToggle?: (enabled: boolean) => void;
-  showIncomingAnimation?: boolean;
-  onAnimationComplete?: () => void;
 }
 
 export const NotebookViewer: React.FC<NotebookViewerProps> = ({
   debugMode = false,
   onDebugToggle,
-  showIncomingAnimation = false,
-  onAnimationComplete,
 }) => {
   const { store } = useStore();
   const {
@@ -53,21 +49,6 @@ export const NotebookViewer: React.FC<NotebookViewerProps> = ({
   } = useAuth();
   const { presentUsers, getUserInfo, getUserColor } = useUserRegistry();
   const { models } = useAvailableAiModels();
-
-  // Animation state for magical logo transition
-  const [animationComplete, setAnimationComplete] = useState(
-    !showIncomingAnimation
-  );
-
-  useEffect(() => {
-    if (showIncomingAnimation) {
-      const timer = setTimeout(() => {
-        setAnimationComplete(true);
-        onAnimationComplete?.();
-      }, 1200);
-      return () => clearTimeout(timer);
-    }
-  }, [showIncomingAnimation, onAnimationComplete]);
 
   const cells = useQuery(
     queryDb(tables.cells.select().orderBy("position", "asc"))
@@ -332,15 +313,7 @@ export const NotebookViewer: React.FC<NotebookViewerProps> = ({
               <img
                 src="/runes.png"
                 alt=""
-                className={`pixel-logo absolute inset-0 h-full w-full ${
-                  !animationComplete
-                    ? `transition-all duration-1200 ease-out ${
-                        showIncomingAnimation
-                          ? "translate-x-0 opacity-100"
-                          : "-translate-x-[220vw] opacity-0"
-                      }`
-                    : ""
-                }`}
+                className="pixel-logo absolute inset-0 h-full w-full"
               />
 
               <img


### PR DESCRIPTION
- Remove setTimeout from NotebookLoadingScreen portal animation
- Remove unnecessary header runes animation (portal covers screen)
- Simplify component props by removing showIncomingAnimation/onAnimationComplete
- Clean up unused animation state and imports
- All animations now properly chained through React Spring's onRest callbacks

Final cleanup of all the other animation bits introduced in the past day.