### PR TITLE
Refactor the auth code to support getPassport

### DIFF
--- a/backend/auth.ts
+++ b/backend/auth.ts
@@ -1,12 +1,18 @@
-import { SignJWT, jwtVerify, createRemoteJWKSet } from "jose";
-import { JWTPayload, decodeJwt } from "jose";
+import * as jose from "jose";
 import { Env } from "./types";
 
 export type ValidatedUser = {
   id: string;
-  email?: string;
+  email: string;
   name?: string;
+  givenName?: string;
+  familyName?: string;
   isAnonymous: boolean;
+};
+
+export type Passport = {
+  jwt: jose.JWTPayload;
+  user: ValidatedUser;
 };
 
 interface AuthPayload {
@@ -35,12 +41,76 @@ export function validateProductionEnvironment(env: Env): void {
   }
 }
 
+function extractBearerToken(request: Request): string | null {
+  const authHeader = request.headers.get("Authorization");
+  if (!authHeader || !authHeader.toLowerCase().startsWith("bearer ")) {
+    return null;
+  }
+  return authHeader.substring(7);
+}
+
+export function getPassport(
+  request: Request,
+  env: Env,
+  verify?: jose.JWTVerifyOptions
+): Promise<Passport> {
+  const token = extractBearerToken(request);
+  if (!token) {
+    throw new jose.errors.JWTInvalid("Missing Authorization header");
+  }
+  return parseToken(token, env, verify);
+}
+
+export async function parseToken(
+  token: string,
+  env: Env,
+  verify?: jose.JWTVerifyOptions
+): Promise<Passport> {
+  const decoded = jose.decodeJwt(token);
+  if (decoded.iss !== env.AUTH_ISSUER) {
+    throw new jose.errors.JWTInvalid("Invalid issuer");
+  }
+  const jwks = jose.createRemoteJWKSet(
+    new URL(`${env.AUTH_ISSUER}/.well-known/jwks.json`),
+    { [jose.customFetch]: env.customFetch }
+  );
+  const { payload: jwt } = await jose.jwtVerify(token, jwks, {
+    algorithms: ["RS256"],
+    issuer: env.AUTH_ISSUER,
+    ...verify,
+  });
+  const { sub, email } = jwt;
+  if (!(typeof sub === "string") || !sub) {
+    throw new jose.errors.JWTInvalid("Invalid sub claim");
+  }
+
+  if (!(typeof email === "string") || !sub) {
+    throw new jose.errors.JWTInvalid("Invalid email claim");
+  }
+
+  const name = getDisplayName(jwt);
+  const givenName =
+    typeof jwt.given_name === "string" ? jwt.given_name : undefined;
+  const familyName =
+    typeof jwt.family_name === "string" ? jwt.family_name : undefined;
+
+  const user: ValidatedUser = {
+    id: sub,
+    email,
+    name,
+    givenName,
+    familyName,
+    isAnonymous: false,
+  };
+  return { jwt, user };
+}
+
 export function determineAuthType(
   payload: AuthPayload,
   env: Env
 ): "access_token" | "auth_token" {
   try {
-    decodeJwt(payload.authToken);
+    jose.decodeJwt(payload.authToken);
     return "access_token";
   } catch {
     // Not a valid JWT, try auth token
@@ -76,7 +146,9 @@ async function validateHardcodedAuthToken(
   // If we can verify the jwt with both secrets, then the secrets must be the same
   // Or if not the same, then computationally impractical to find a hash collision
   // TL;DR: This function is a very roundabout way of checking if env.AUTH_TOKEN === payload.authToken
-  const jwtBuilder = new SignJWT({ sub: "example-user" }).setProtectedHeader({
+  const jwtBuilder = new jose.SignJWT({
+    sub: "example-user",
+  }).setProtectedHeader({
     alg: "HS256",
   });
   const expectedSecret = new TextEncoder().encode(env.AUTH_TOKEN);
@@ -84,7 +156,7 @@ async function validateHardcodedAuthToken(
   const jwt = await jwtBuilder.sign(expectedSecret);
 
   try {
-    await jwtVerify(jwt, expectedSecret, {
+    await jose.jwtVerify(jwt, expectedSecret, {
       algorithms: ["HS256"],
     });
   } catch {
@@ -95,7 +167,7 @@ async function validateHardcodedAuthToken(
   }
 
   try {
-    await jwtVerify(jwt, actualSecret, {
+    await jose.jwtVerify(jwt, actualSecret, {
       algorithms: ["HS256"],
     });
   } catch {
@@ -107,6 +179,7 @@ async function validateHardcodedAuthToken(
     return {
       id: "runtime-agent",
       name: "Runtime Agent",
+      email: "runtime-agent@example.com",
       isAnonymous: false,
     };
   }
@@ -122,42 +195,11 @@ async function validateOAuthToken(
   payload: AuthPayload,
   env: Env
 ): Promise<ValidatedUser> {
-  const JWKS = createRemoteJWKSet(
-    new URL(`${env.AUTH_ISSUER}/.well-known/jwks.json`)
-  );
-
-  let jwt: JWTPayload;
-  try {
-    const resp = await jwtVerify(payload.authToken, JWKS, {
-      algorithms: ["RS256"],
-      issuer: env.AUTH_ISSUER,
-    });
-    jwt = resp.payload;
-  } catch (error) {
-    const errorMessage =
-      error instanceof Error ? error.message : "Unknown error";
-    throw new Error(`VALIDATE_JWT_ERROR: ${errorMessage}`);
-  }
-
-  const { sub } = jwt;
-  if (!(typeof sub === "string")) {
-    throw new Error("INVALID_JWT_TOKEN: JWT missing sub claim");
-  }
-
-  const email = typeof jwt.email === "string" ? jwt.email : undefined;
-  const name = getDisplayName(jwt);
-
-  const user: ValidatedUser = {
-    id: sub,
-    email,
-    name,
-    isAnonymous: false,
-  };
-  console.log("🔑 Validated user", user);
+  const { user } = await parseToken(payload.authToken, env);
   return user;
 }
 
-const getDisplayName = (jwt: JWTPayload): string => {
+const getDisplayName = (jwt: jose.JWTPayload): string => {
   if (typeof jwt.name === "string") {
     return jwt.name;
   }

--- a/backend/types.ts
+++ b/backend/types.ts
@@ -28,4 +28,6 @@ export type Env = {
 
   // Whether to enable the local_oidc routes
   ALLOW_LOCAL_AUTH?: string;
+
+  customFetch?: typeof fetch; // Only used in unit tests to mock fetch
 };


### PR DESCRIPTION
This will be the primary way going forwards that sub-routes can validate that the user is authorized, information about the user (and in the future things like scopes, api key info etc)

The code in local_oidc in the userinfo endpoint is a good example We can continue to add more helpers around e.g. the error codes as we go on