### PR TITLE
Add detail to auth issuer error

### DIFF
--- a/src/components/auth/LoginPrompt.tsx
+++ b/src/components/auth/LoginPrompt.tsx
@@ -85,7 +85,9 @@ const LoginPrompt: React.FC<LoginPromptProps> = ({
           error.message.includes("unexpected response content-type") &&
           providerName === null
         ) {
-          setError("ALLOW_LOCAL_AUTH not enabled");
+          setError(
+            "ALLOW_LOCAL_AUTH not enabled, or you should check that AUTH_ISSUER is set in your .dev.vars file"
+          );
         } else {
           setError(error.message);
         }


### PR DESCRIPTION
I needed to copy the .dev.vars.example file again and didn't realize it

I think ideally we have .env defaults that work without any env vars in development and if we do want to make sure we don't forget vars, we should first check that we're in prod