### PR TITLE
Rely on useQuery in all components

### DIFF
--- a/src/components/notebook/cell/AiCell.tsx
+++ b/src/components/notebook/cell/AiCell.tsx
@@ -7,7 +7,7 @@ import { useUserRegistry } from "@/hooks/useUserRegistry.js";
 import { useToolApprovals } from "@/hooks/useToolApprovals.js";
 import { useAvailableAiModels } from "@/util/ai-models.js";
 import { queryDb } from "@livestore/livestore";
-import { useStore } from "@livestore/react";
+import { useStore, useQuery } from "@livestore/react";
 import { events, tables } from "@runt/schema";
 import { ChevronDown, ChevronUp } from "lucide-react";
 import React, { useCallback } from "react";
@@ -175,12 +175,13 @@ export const AiCell: React.FC<AiCellProps> = ({
     }
   }, [cell.id, localSource, cell.source, cell.executionCount, store, userId]);
 
+  // Query execution queue for this cell
+  const executionQueue = useQuery(
+    queryDb(tables.executionQueue.select().where({ cellId: cell.id }))
+  );
+
   const interruptAiCell = useCallback(async () => {
     // Find the current execution in the queue for this cell
-    const executionQueue = store.query(
-      queryDb(tables.executionQueue.select().where({ cellId: cell.id }))
-    );
-
     const currentExecution = executionQueue.find(
       (exec: any) =>
         exec.status === "executing" ||
@@ -198,7 +199,7 @@ export const AiCell: React.FC<AiCellProps> = ({
         })
       );
     }
-  }, [cell.id, store, userId]);
+  }, [cell.id, store, userId, executionQueue]);
 
   // Use shared keyboard navigation hook
   const { keyMap } = useCellKeyboardNavigation({

--- a/src/components/notebook/cell/CodeCell.tsx
+++ b/src/components/notebook/cell/CodeCell.tsx
@@ -6,7 +6,7 @@ import { useCellOutputs } from "@/hooks/useCellOutputs.js";
 import { useAuth } from "@/components/auth/AuthProvider.js";
 import { useUserRegistry } from "@/hooks/useUserRegistry.js";
 import { queryDb } from "@livestore/livestore";
-import { useStore } from "@livestore/react";
+import { useStore, useQuery } from "@livestore/react";
 import { events, tables } from "@runt/schema";
 import { ChevronDown, ChevronUp } from "lucide-react";
 import React, { useCallback } from "react";
@@ -188,11 +188,13 @@ export const CodeCell: React.FC<CodeCellProps> = ({
     }
   }, [cell.id, localSource, cell.source, cell.executionCount, store, userId]);
 
+  // Query execution queue for this cell
+  const executionQueue = useQuery(
+    queryDb(tables.executionQueue.select().where({ cellId: cell.id }))
+  );
+
   const interruptCell = useCallback(async () => {
     // Find the current execution in the queue for this cell
-    const executionQueue = store.query(
-      queryDb(tables.executionQueue.select().where({ cellId: cell.id }))
-    );
 
     const currentExecution = executionQueue.find(
       (exec: any) =>
@@ -211,7 +213,7 @@ export const CodeCell: React.FC<CodeCellProps> = ({
         })
       );
     }
-  }, [cell.id, store, userId]);
+  }, [cell.id, store, userId, executionQueue]);
 
   // Use shared keyboard navigation hook
   const { keyMap } = useCellKeyboardNavigation({

--- a/src/components/notebook/cell/SqlCell.tsx
+++ b/src/components/notebook/cell/SqlCell.tsx
@@ -5,7 +5,7 @@ import { useCellOutputs } from "@/hooks/useCellOutputs.js";
 import { useAuth } from "@/components/auth/AuthProvider.js";
 import { useUserRegistry } from "@/hooks/useUserRegistry.js";
 import { queryDb } from "@livestore/livestore";
-import { useStore } from "@livestore/react";
+import { useStore, useQuery } from "@livestore/react";
 import { events, tables } from "@runt/schema";
 import { ChevronDown, ChevronUp } from "lucide-react";
 import React, { useCallback } from "react";
@@ -105,11 +105,13 @@ export const SqlCell: React.FC<SqlCellProps> = ({
     }
   }, [cell.id, store, hasOutputs, userId]);
 
+  // Query execution queue for this cell
+  const executionQueue = useQuery(
+    queryDb(tables.executionQueue.select().where({ cellId: cell.id }))
+  );
+
   const interruptQuery = useCallback(() => {
     // Find the current execution in the queue for this cell
-    const executionQueue = store.query(
-      queryDb(tables.executionQueue.select().where({ cellId: cell.id }))
-    );
 
     const currentExecution = executionQueue.find(
       (exec: any) =>
@@ -128,7 +130,7 @@ export const SqlCell: React.FC<SqlCellProps> = ({
         })
       );
     }
-  }, [cell.id, store, userId]);
+  }, [cell.id, store, userId, executionQueue]);
 
   // Use shared keyboard navigation hook
   const { keyMap } = useCellKeyboardNavigation({


### PR DESCRIPTION
Refactor cell components to use the useQuery hook instead of store.query() pattern.

This change aligns with React compiler requirements and LiveStore best practices by:
- Moving execution queue queries out of callback functions
- Using reactive useQuery hook for consistent state updates
- Fixing React compiler ESLint errors

Updated components:
- AiCell.tsx
- CodeCell.tsx  
- SqlCell.tsx