### PR TITLE
Refactor interrupt execution logic into shared hook

### DIFF
--- a/src/components/notebook/cell/AiCell.tsx
+++ b/src/components/notebook/cell/AiCell.tsx
@@ -5,9 +5,10 @@ import { useCellOutputs } from "@/hooks/useCellOutputs.js";
 import { useAuth } from "@/components/auth/AuthProvider.js";
 import { useUserRegistry } from "@/hooks/useUserRegistry.js";
 import { useToolApprovals } from "@/hooks/useToolApprovals.js";
+import { useInterruptExecution } from "@/hooks/useInterruptExecution.js";
 import { useAvailableAiModels } from "@/util/ai-models.js";
-import { queryDb } from "@livestore/livestore";
-import { useStore, useQuery } from "@livestore/react";
+
+import { useStore } from "@livestore/react";
 import { events, tables } from "@runt/schema";
 import { ChevronDown, ChevronUp } from "lucide-react";
 import React, { useCallback } from "react";
@@ -175,31 +176,11 @@ export const AiCell: React.FC<AiCellProps> = ({
     }
   }, [cell.id, localSource, cell.source, cell.executionCount, store, userId]);
 
-  // Query execution queue for this cell
-  const executionQueue = useQuery(
-    queryDb(tables.executionQueue.select().where({ cellId: cell.id }))
-  );
-
-  const interruptAiCell = useCallback(async () => {
-    // Find the current execution in the queue for this cell
-    const currentExecution = executionQueue.find(
-      (exec: any) =>
-        exec.status === "executing" ||
-        exec.status === "pending" ||
-        exec.status === "assigned"
-    );
-
-    if (currentExecution) {
-      store.commit(
-        events.executionCancelled({
-          queueId: currentExecution.id,
-          cellId: cell.id,
-          cancelledBy: userId,
-          reason: "User interrupted AI execution",
-        })
-      );
-    }
-  }, [cell.id, store, userId, executionQueue]);
+  const { interruptExecution: interruptAiCell } = useInterruptExecution({
+    cellId: cell.id,
+    userId,
+    reason: "User interrupted AI execution",
+  });
 
   // Use shared keyboard navigation hook
   const { keyMap } = useCellKeyboardNavigation({

--- a/src/components/notebook/cell/AiCell.tsx
+++ b/src/components/notebook/cell/AiCell.tsx
@@ -7,7 +7,7 @@ import { useUserRegistry } from "@/hooks/useUserRegistry.js";
 import { useToolApprovals } from "@/hooks/useToolApprovals.js";
 import { useAvailableAiModels } from "@/util/ai-models.js";
 import { queryDb } from "@livestore/livestore";
-import { useStore } from "@livestore/react";
+import { useStore, useQuery } from "@livestore/react";
 import { events, tables } from "@runt/schema";
 import { ChevronDown, ChevronUp } from "lucide-react";
 import React, { useCallback } from "react";
@@ -175,12 +175,13 @@ export const AiCell: React.FC<AiCellProps> = ({
     }
   }, [cell.id, localSource, cell.source, cell.executionCount, store, userId]);
 
+  // Query execution queue for this cell
+  const executionQueue = useQuery(
+    queryDb(tables.executionQueue.select().where({ cellId: cell.id }))
+  );
+
   const interruptAiCell = useCallback(async () => {
     // Find the current execution in the queue for this cell
-    const executionQueue = store.query(
-      queryDb(tables.executionQueue.select().where({ cellId: cell.id }))
-    );
-
     const currentExecution = executionQueue.find(
       (exec: any) =>
         exec.status === "executing" ||
@@ -198,7 +199,7 @@ export const AiCell: React.FC<AiCellProps> = ({
         })
       );
     }
-  }, [cell.id, store, userId]);
+  }, [cell.id, store, userId, executionQueue]);
 
   // Use shared keyboard navigation hook
   const { keyMap } = useCellKeyboardNavigation({

--- a/src/components/notebook/cell/CodeCell.tsx
+++ b/src/components/notebook/cell/CodeCell.tsx
@@ -6,7 +6,7 @@ import { useCellOutputs } from "@/hooks/useCellOutputs.js";
 import { useAuth } from "@/components/auth/AuthProvider.js";
 import { useUserRegistry } from "@/hooks/useUserRegistry.js";
 import { queryDb } from "@livestore/livestore";
-import { useStore } from "@livestore/react";
+import { useStore, useQuery } from "@livestore/react";
 import { events, tables } from "@runt/schema";
 import { ChevronDown, ChevronUp } from "lucide-react";
 import React, { useCallback } from "react";
@@ -188,11 +188,13 @@ export const CodeCell: React.FC<CodeCellProps> = ({
     }
   }, [cell.id, localSource, cell.source, cell.executionCount, store, userId]);
 
+  // Query execution queue for this cell
+  const executionQueue = useQuery(
+    queryDb(tables.executionQueue.select().where({ cellId: cell.id }))
+  );
+
   const interruptCell = useCallback(async () => {
     // Find the current execution in the queue for this cell
-    const executionQueue = store.query(
-      queryDb(tables.executionQueue.select().where({ cellId: cell.id }))
-    );
 
     const currentExecution = executionQueue.find(
       (exec: any) =>
@@ -211,7 +213,7 @@ export const CodeCell: React.FC<CodeCellProps> = ({
         })
       );
     }
-  }, [cell.id, store, userId]);
+  }, [cell.id, store, userId, executionQueue]);
 
   // Use shared keyboard navigation hook
   const { keyMap } = useCellKeyboardNavigation({

--- a/src/components/notebook/cell/SqlCell.tsx
+++ b/src/components/notebook/cell/SqlCell.tsx
@@ -5,7 +5,7 @@ import { useCellOutputs } from "@/hooks/useCellOutputs.js";
 import { useAuth } from "@/components/auth/AuthProvider.js";
 import { useUserRegistry } from "@/hooks/useUserRegistry.js";
 import { queryDb } from "@livestore/livestore";
-import { useStore } from "@livestore/react";
+import { useStore, useQuery } from "@livestore/react";
 import { events, tables } from "@runt/schema";
 import { ChevronDown, ChevronUp } from "lucide-react";
 import React, { useCallback } from "react";
@@ -105,11 +105,13 @@ export const SqlCell: React.FC<SqlCellProps> = ({
     }
   }, [cell.id, store, hasOutputs, userId]);
 
+  // Query execution queue for this cell
+  const executionQueue = useQuery(
+    queryDb(tables.executionQueue.select().where({ cellId: cell.id }))
+  );
+
   const interruptQuery = useCallback(() => {
     // Find the current execution in the queue for this cell
-    const executionQueue = store.query(
-      queryDb(tables.executionQueue.select().where({ cellId: cell.id }))
-    );
 
     const currentExecution = executionQueue.find(
       (exec: any) =>
@@ -128,7 +130,7 @@ export const SqlCell: React.FC<SqlCellProps> = ({
         })
       );
     }
-  }, [cell.id, store, userId]);
+  }, [cell.id, store, userId, executionQueue]);
 
   // Use shared keyboard navigation hook
   const { keyMap } = useCellKeyboardNavigation({

--- a/src/hooks/useInterruptExecution.ts
+++ b/src/hooks/useInterruptExecution.ts
@@ -1,0 +1,54 @@
+import { useCallback } from "react";
+import { useStore, useQuery } from "@livestore/react";
+import { queryDb } from "@livestore/livestore";
+import { events, tables } from "@runt/schema";
+
+interface UseInterruptExecutionOptions {
+  cellId: string;
+  userId: string;
+  reason?: string;
+}
+
+export function useInterruptExecution({
+  cellId,
+  userId,
+  reason = "User interrupted execution",
+}: UseInterruptExecutionOptions) {
+  const { store } = useStore();
+
+  // Query execution queue for this cell
+  const executionQueue = useQuery(
+    queryDb(tables.executionQueue.select().where({ cellId }))
+  );
+
+  const interruptExecution = useCallback(() => {
+    // Find the current execution in the queue for this cell
+    const currentExecution = executionQueue.find(
+      (exec: any) =>
+        exec.status === "executing" ||
+        exec.status === "pending" ||
+        exec.status === "assigned"
+    );
+
+    if (currentExecution) {
+      store.commit(
+        events.executionCancelled({
+          queueId: currentExecution.id,
+          cellId,
+          cancelledBy: userId,
+          reason,
+        })
+      );
+    }
+  }, [cellId, store, userId, executionQueue, reason]);
+
+  return {
+    interruptExecution,
+    hasActiveExecution: executionQueue.some(
+      (exec: any) =>
+        exec.status === "executing" ||
+        exec.status === "pending" ||
+        exec.status === "assigned"
+    ),
+  };
+}


### PR DESCRIPTION
Extract duplicated execution interruption logic into a reusable hook.

Changes:
- Created `useInterruptExecution` hook that encapsulates query and interrupt logic
- Replaced duplicated code in AiCell, CodeCell, and SqlCell
- Hook returns both `interruptExecution` function and `hasActiveExecution` state
- Customizable cancellation reasons for different cell types

This follows our established pattern of shared hooks and reduces code duplication across cell components.