### PR TITLE
refactor: centralize @runt/schema imports

### DIFF
--- a/src/components/auth/UserProfile.tsx
+++ b/src/components/auth/UserProfile.tsx
@@ -3,7 +3,7 @@ import { useAuth, UserInfo } from "./AuthProvider.js";
 import { useUserRegistry } from "../../hooks/useUserRegistry.js";
 import { AvatarWithDetails } from "../ui/AvatarWithDetails.js";
 import { useStore, useQuery } from "@livestore/react";
-import { events, tables } from "@runt/schema";
+import { events, tables } from "@/schema";
 import { queryDb } from "@livestore/livestore";
 
 interface UserProfileProps {

--- a/src/components/notebook/DebugPanel.tsx
+++ b/src/components/notebook/DebugPanel.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import { useQuery, useStore } from "@livestore/react";
 import { queryDb, sql, Schema } from "@livestore/livestore";
 
-import { tables, events } from "@runt/schema";
+import { tables, events } from "@/schema";
 import { schema } from "../../schema.js";
 import { Bug, Database } from "lucide-react";
 import { Button } from "@/components/ui/button";

--- a/src/components/notebook/MobileOmnibar.tsx
+++ b/src/components/notebook/MobileOmnibar.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { useStore, useQuery } from "@livestore/react";
-import { events, CellData, tables } from "@runt/schema";
+import { events, CellData, tables } from "@/schema";
 import { queryDb } from "@livestore/livestore";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";

--- a/src/components/notebook/NotebookTitle.tsx
+++ b/src/components/notebook/NotebookTitle.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useState } from "react";
 import { useStore, useQuery } from "@livestore/react";
-import { events, tables } from "@runt/schema";
+import { events, tables } from "@/schema";
 import { queryDb } from "@livestore/livestore";
 import { Input } from "@/components/ui/input";
 

--- a/src/components/notebook/NotebookViewer.tsx
+++ b/src/components/notebook/NotebookViewer.tsx
@@ -1,6 +1,6 @@
 import { queryDb } from "@livestore/livestore";
 import { useQuery, useStore } from "@livestore/react";
-import { CellData, events, tables } from "@runt/schema";
+import { CellData, events, tables } from "@/schema";
 import React, { Suspense, useCallback } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 

--- a/src/components/notebook/RuntimeHelper.tsx
+++ b/src/components/notebook/RuntimeHelper.tsx
@@ -2,7 +2,7 @@ import React, { useCallback } from "react";
 import { Button } from "@/components/ui/button";
 import { useRuntimeHealth } from "@/hooks/useRuntimeHealth.js";
 import { useStore } from "@livestore/react";
-import { events } from "@runt/schema";
+import { events } from "@/schema";
 import { useAuth } from "@/components/auth/AuthProvider.js";
 import { getRuntimeCommand } from "@/util/runtime-command.js";
 import { getCurrentNotebookId } from "@/util/store-id.js";

--- a/src/components/notebook/VirtualizedCellList.tsx
+++ b/src/components/notebook/VirtualizedCellList.tsx
@@ -1,4 +1,4 @@
-import { CellData } from "@runt/schema";
+import { CellData } from "@/schema";
 import React, {
   useCallback,
   useEffect,

--- a/src/components/notebook/cell/AiCell.tsx
+++ b/src/components/notebook/cell/AiCell.tsx
@@ -8,7 +8,7 @@ import { useToolApprovals } from "@/hooks/useToolApprovals.js";
 import { useAvailableAiModels } from "@/util/ai-models.js";
 import { queryDb } from "@livestore/livestore";
 import { useStore } from "@livestore/react";
-import { events, tables } from "@runt/schema";
+import { events, tables } from "@/schema";
 import { ChevronDown, ChevronUp } from "lucide-react";
 import React, { useCallback } from "react";
 import { ErrorBoundary } from "react-error-boundary";

--- a/src/components/notebook/cell/Cell.tsx
+++ b/src/components/notebook/cell/Cell.tsx
@@ -1,4 +1,4 @@
-import { tables } from "@runt/schema";
+import { tables } from "@/schema";
 import React from "react";
 
 import { AiCell } from "./AiCell.js";

--- a/src/components/notebook/cell/CellBetweener.tsx
+++ b/src/components/notebook/cell/CellBetweener.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@/components/ui/button";
-import { CellData } from "@runt/schema";
+import { CellData } from "@/schema";
 import { Plus } from "lucide-react";
 
 export function CellBetweener({

--- a/src/components/notebook/cell/CodeCell.tsx
+++ b/src/components/notebook/cell/CodeCell.tsx
@@ -7,7 +7,7 @@ import { useAuth } from "@/components/auth/AuthProvider.js";
 import { useUserRegistry } from "@/hooks/useUserRegistry.js";
 import { queryDb } from "@livestore/livestore";
 import { useStore } from "@livestore/react";
-import { events, tables } from "@runt/schema";
+import { events, tables } from "@/schema";
 import { ChevronDown, ChevronUp } from "lucide-react";
 import React, { useCallback } from "react";
 import { ErrorBoundary } from "react-error-boundary";

--- a/src/components/notebook/cell/MarkdownCell.tsx
+++ b/src/components/notebook/cell/MarkdownCell.tsx
@@ -2,7 +2,7 @@ import { useCellContent } from "@/hooks/useCellContent.js";
 import { useCellKeyboardNavigation } from "@/hooks/useCellKeyboardNavigation.js";
 import { useCellOutputs } from "@/hooks/useCellOutputs.js";
 import { useStore } from "@livestore/react";
-import { events, tables } from "@runt/schema";
+import { events, tables } from "@/schema";
 import React, {
   useCallback,
   useEffect,

--- a/src/components/notebook/cell/SqlCell.tsx
+++ b/src/components/notebook/cell/SqlCell.tsx
@@ -6,7 +6,7 @@ import { useAuth } from "@/components/auth/AuthProvider.js";
 import { useUserRegistry } from "@/hooks/useUserRegistry.js";
 import { queryDb } from "@livestore/livestore";
 import { useStore } from "@livestore/react";
-import { events, tables } from "@runt/schema";
+import { events, tables } from "@/schema";
 import { ChevronDown, ChevronUp } from "lucide-react";
 import React, { useCallback } from "react";
 import { ErrorBoundary } from "react-error-boundary";

--- a/src/components/notebook/cell/shared/CellContainer.tsx
+++ b/src/components/notebook/cell/shared/CellContainer.tsx
@@ -1,4 +1,4 @@
-import { tables } from "@runt/schema";
+import { tables } from "@/schema";
 import { forwardRef, ReactNode } from "react";
 import "./PresenceIndicators.css";
 

--- a/src/components/notebook/cell/shared/CellTypeSelector.tsx
+++ b/src/components/notebook/cell/shared/CellTypeSelector.tsx
@@ -7,7 +7,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Bot, Code, Database, FileText } from "lucide-react";
-import { tables } from "@runt/schema";
+import { tables } from "@/schema";
 
 interface CellTypeSelectorProps {
   cell: typeof tables.cells.Type;

--- a/src/components/notebook/cell/shared/Editor.tsx
+++ b/src/components/notebook/cell/shared/Editor.tsx
@@ -1,7 +1,7 @@
 import { cn } from "@/lib/utils";
 import { KeyBinding } from "@codemirror/view";
 import * as Dialog from "@radix-ui/react-dialog";
-import { tables } from "@runt/schema";
+import { tables } from "@/schema";
 import { Maximize2, Minimize2 } from "lucide-react";
 import { useState } from "react";
 import { Button } from "@/components/ui/button";

--- a/src/components/outputs/AiToolCallOutput.tsx
+++ b/src/components/outputs/AiToolCallOutput.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { oneLight } from "react-syntax-highlighter/dist/esm/styles/prism";
 import { ChevronDown, Edit, FilePlus, Info } from "lucide-react";
-import { AiToolCallData } from "@runt/schema";
+import { AiToolCallData } from "@/schema";
 
 interface AiToolCallOutputProps {
   toolData: AiToolCallData;

--- a/src/components/outputs/AiToolResultOutput.tsx
+++ b/src/components/outputs/AiToolResultOutput.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { CheckCircle, XCircle, Clock, Info } from "lucide-react";
-import { AiToolResultData } from "@runt/schema";
+import { AiToolResultData } from "@/schema";
 
 interface AiToolResultOutputProps {
   resultData: AiToolResultData;

--- a/src/components/outputs/RichOutput.tsx
+++ b/src/components/outputs/RichOutput.tsx
@@ -12,7 +12,7 @@ import {
   APPLICATION_MIME_TYPES,
   IMAGE_MIME_TYPES,
   JUPYTER_MIME_TYPES,
-} from "@runt/schema";
+} from "@/schema";
 import { AnsiStreamOutput } from "@/components/outputs";
 import { AnsiErrorOutput } from "@/components/outputs/AnsiOutput.js";
 import { outputDeltasQuery, getFinalContent } from "@/queries/outputDeltas";

--- a/src/components/outputs/index.ts
+++ b/src/components/outputs/index.ts
@@ -15,11 +15,7 @@ export { SvgOutput } from "./SvgOutput.js";
 // to reduce bundle size. They are no longer exported from this index file.
 
 // Re-export types from schema for consistency
-export type {
-  OutputData,
-  AiToolCallData,
-  AiToolResultData,
-} from "@runt/schema";
+export type { OutputData, AiToolCallData, AiToolResultData } from "@/schema";
 
 // Legacy type aliases for backward compatibility
 export type ToolCallData = import("@runt/schema").AiToolCallData;

--- a/src/hooks/useCellContent.ts
+++ b/src/hooks/useCellContent.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import { useStore } from "@livestore/react";
-import { events } from "@runt/schema";
+import { events } from "@/schema";
 import { useAuth } from "@/components/auth/AuthProvider.js";
 
 interface CellContentOptions {

--- a/src/hooks/useCellOutputs.tsx
+++ b/src/hooks/useCellOutputs.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useCallback } from "react";
-import { OutputData, tables, MediaContainer } from "@runt/schema";
+import { OutputData, tables, MediaContainer } from "@/schema";
 import { queryDb } from "@livestore/livestore";
 import { useQuery } from "@livestore/react";
 import { groupConsecutiveStreamOutputs } from "../util/output-grouping.js";

--- a/src/hooks/useCellPresence.ts
+++ b/src/hooks/useCellPresence.ts
@@ -1,6 +1,6 @@
 import { useQuery } from "@livestore/react";
 import { queryDb } from "@livestore/livestore";
-import { tables } from "@runt/schema";
+import { tables } from "@/schema";
 import { useCallback } from "react";
 
 import { useAuth } from "@/components/auth/AuthProvider.js";

--- a/src/hooks/useRuntimeHealth.ts
+++ b/src/hooks/useRuntimeHealth.ts
@@ -1,6 +1,6 @@
 import { useQuery } from "@livestore/react";
 import { queryDb } from "@livestore/livestore";
-import { RuntimeSessionData, tables } from "@runt/schema";
+import { RuntimeSessionData, tables } from "@/schema";
 import { useCallback } from "react";
 
 export type RuntimeHealth =

--- a/src/hooks/useToolApprovals.ts
+++ b/src/hooks/useToolApprovals.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
 import { useStore, useQuery } from "@livestore/react";
 import { queryDb } from "@livestore/livestore";
-import { events, tables } from "@runt/schema";
+import { events, tables } from "@/schema";
 import { useAuth } from "@/components/auth/AuthProvider.js";
 
 export type ToolApprovalRequest = {

--- a/src/hooks/useUserRegistry.ts
+++ b/src/hooks/useUserRegistry.ts
@@ -1,7 +1,7 @@
 import { useCallback, useMemo } from "react";
 import { useQuery } from "@livestore/react";
 import { queryDb } from "@livestore/livestore";
-import { tables } from "@runt/schema";
+import { tables } from "@/schema";
 
 import { generateInitials, generateColor } from "../util/avatar.js";
 import {

--- a/src/queries/index.ts
+++ b/src/queries/index.ts
@@ -1,4 +1,4 @@
-import { tables } from "@runt/schema";
+import { tables } from "@/schema";
 import { queryDb } from "@livestore/livestore";
 
 export * from "./outputDeltas";

--- a/src/queries/outputDeltas.ts
+++ b/src/queries/outputDeltas.ts
@@ -1,4 +1,4 @@
-import { tables } from "@runt/schema";
+import { tables } from "@/schema";
 import { queryDb } from "@livestore/livestore";
 
 interface OutputDelta {

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -6,5 +6,40 @@ const state = State.SQLite.makeState({ tables, materializers });
 export const schema = makeSchema({ events, state });
 export type Store = LiveStore<typeof schema>;
 
-// Export the schema components for use in the app
-export { events, tables, materializers };
+// Re-export core schema components
+export { events, tables, materializers } from "@runt/schema";
+
+// Re-export types
+export type {
+  CellData,
+  RuntimeSessionData,
+  MediaContainer,
+  OutputData,
+  AiToolCallData,
+  AiToolResultData,
+} from "@runt/schema";
+
+// Re-export functions
+export {
+  fractionalIndexBetween,
+  createCellAfter,
+  createCellBefore,
+} from "@runt/schema";
+
+// Re-export type guards
+export {
+  isInlineContainer,
+  isArtifactContainer,
+  isAiToolCallData,
+  isAiToolResultData,
+} from "@runt/schema";
+
+// Re-export constants
+export {
+  IMAGE_MIME_TYPES,
+  JUPYTER_MIME_TYPES,
+  AI_TOOL_CALL_MIME_TYPE,
+  AI_TOOL_RESULT_MIME_TYPE,
+  TEXT_MIME_TYPES,
+  APPLICATION_MIME_TYPES,
+} from "@runt/schema";

--- a/src/util/ai-models.ts
+++ b/src/util/ai-models.ts
@@ -1,6 +1,6 @@
 import { useQuery } from "@livestore/react";
 import { queryDb } from "@livestore/livestore";
-import { tables } from "@runt/schema";
+import { tables } from "@/schema";
 import { useMemo } from "react";
 
 export type AiModel = {

--- a/src/util/output-grouping.ts
+++ b/src/util/output-grouping.ts
@@ -1,4 +1,4 @@
-import { OutputData } from "@runt/schema";
+import { OutputData } from "@/schema";
 
 /**
  * Groups consecutive terminal outputs of the same type (stdout/stderr) into single outputs

--- a/test/output-grouping.test.ts
+++ b/test/output-grouping.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { groupConsecutiveStreamOutputs } from "../src/util/output-grouping.js";
-import { OutputData } from "@runt/schema";
+import { OutputData } from "@/schema";
 
 // Helper to create minimal test objects with only the fields the function uses
 function createTerminalOutput(
@@ -38,12 +38,12 @@ function createMultimediaOutput(
     streamName: null,
     executionCount: outputType === "multimedia_result" ? 1 : null,
     displayId: outputType === "multimedia_display" ? null : null,
-    data: "test data",
+    data: { "text/plain": { data: "test data", type: "inline" } },
     artifactId: null,
     mimeType: "text/plain",
     metadata: null,
-    representations: { "text/plain": "test data" },
-  } as OutputData;
+    representations: null,
+  } as any as OutputData;
 }
 
 describe("groupConsecutiveStreamOutputs", () => {


### PR DESCRIPTION
This PR centralizes all `@runt/schema` imports through `src/schema.ts` to make hot swapping a bit simpler.