### PR TITLE
fix: add AUTH_ISSUER to preview environment vars

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -135,6 +135,7 @@ preview_bucket_name = "anode-artifacts-preview"
 DEPLOYMENT_ENV = "preview"
 ARTIFACT_STORAGE = "r2"
 ARTIFACT_THRESHOLD = "16384"
+AUTH_ISSUER = "https://auth.anaconda.com/api/auth"
 # Vite build-time variables
 VITE_LIVESTORE_SYNC_URL = "/livestore"
 VITE_RUNTIME_COMMAND = "pnpm run dev:runtime"


### PR DESCRIPTION
Fix wrangler.toml configuration warning by adding AUTH_ISSUER to the preview environment vars section. This ensures the preview environment has all required authentication configuration.