### PR TITLE
Fix injecting required env vars in dev mode

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -46,7 +46,7 @@ export default defineConfig(({ mode }) => {
   }
 
   const plugins = [
-    envValidationPlugin(),
+    envValidationPlugin(env),
     injectLoadingScreen(),
     iframeServerPlugin(),
     react({


### PR DESCRIPTION
```js
// in vite.config.ts in `defineConfig`:
const env = loadEnv(mode, process.cwd(), "");
console.log("VITE_IFRAME_OUTPUT_URI=", process.env.VITE_IFRAME_OUTPUT_URI);
console.log("VITE_IFRAME_OUTPUT_URI=", env.VITE_IFRAME_OUTPUT_URI);
```

Assuming `.env` has `VITE_IFRAME_OUTPUT_URI` set.

`process.env.VITE_IFRAME_OUTPUT_URI` is empty and env check was defining it to the default