### PR TITLE
Improve cell navigation and focus management

### DIFF
--- a/src/components/notebook/CellList.tsx
+++ b/src/components/notebook/CellList.tsx
@@ -7,6 +7,7 @@ import { CellReference } from "@/schema";
 interface CellListProps {
   cellReferences: readonly CellReference[];
   focusedCellId: string | null;
+  newlyCreatedCellId: string | null;
   onAddCell: (
     cellId?: string,
     cellType?: "code" | "markdown" | "sql" | "ai",
@@ -18,6 +19,7 @@ interface CellListProps {
   onFocusNext: (cellId: string) => void;
   onFocusPrevious: (cellId: string) => void;
   onFocus: (cellId: string) => void;
+  onNewCellRendered: () => void;
   contextSelectionMode?: boolean;
   // Legacy virtualization props (ignored but kept for compatibility)
   itemHeight?: number;
@@ -28,6 +30,7 @@ interface CellListProps {
 export const CellList: React.FC<CellListProps> = ({
   cellReferences,
   focusedCellId,
+  newlyCreatedCellId,
   onAddCell,
   onDeleteCell,
   onMoveUp,
@@ -35,9 +38,19 @@ export const CellList: React.FC<CellListProps> = ({
   onFocusNext,
   onFocusPrevious,
   onFocus,
+  onNewCellRendered,
   contextSelectionMode = false,
   // Virtualization props ignored
 }) => {
+  // Clear newly created cell status after first render
+  React.useEffect(() => {
+    if (newlyCreatedCellId) {
+      const timer = setTimeout(() => {
+        onNewCellRendered();
+      }, 100);
+      return () => clearTimeout(timer);
+    }
+  }, [newlyCreatedCellId, onNewCellRendered]);
   return (
     <div style={{ paddingLeft: "1rem" }}>
       {cellReferences.map((cellReference, index) => (
@@ -59,6 +72,7 @@ export const CellList: React.FC<CellListProps> = ({
               onFocusPrevious={() => onFocusPrevious(cellReference.id)}
               onFocus={() => onFocus(cellReference.id)}
               autoFocus={cellReference.id === focusedCellId}
+              scrollIntoView={cellReference.id === newlyCreatedCellId}
               contextSelectionMode={contextSelectionMode}
             />
             <CellBetweener

--- a/src/components/notebook/NotebookViewer.tsx
+++ b/src/components/notebook/NotebookViewer.tsx
@@ -320,9 +320,7 @@ export const NotebookViewer: React.FC<NotebookViewerProps> = ({
         setFocusedCellId(nextCell.id);
 
         // Position cursor in the next cell
-        setTimeout(() => {
-          registryFocusCell(nextCell.id, cursorPosition);
-        }, 50);
+        registryFocusCell(nextCell.id, cursorPosition);
       } else {
         // At the last cell, create a new one with same cell type (but never raw)
         const currentCell = cellReferences[currentIndex];
@@ -345,9 +343,7 @@ export const NotebookViewer: React.FC<NotebookViewerProps> = ({
         setFocusedCellId(previousCell.id);
 
         // Position cursor in the previous cell
-        setTimeout(() => {
-          registryFocusCell(previousCell.id, cursorPosition);
-        }, 50);
+        registryFocusCell(previousCell.id, cursorPosition);
       }
     },
     [cellReferences]

--- a/src/components/notebook/NotebookViewer.tsx
+++ b/src/components/notebook/NotebookViewer.tsx
@@ -20,6 +20,7 @@ import { Button } from "@/components/ui/button";
 
 import { useAuth } from "@/components/auth/AuthProvider.js";
 import { useUserRegistry } from "@/hooks/useUserRegistry.js";
+import { useEditorRegistry } from "@/hooks/useEditorRegistry.js";
 
 import { getClientColor, getClientTypeInfo } from "@/services/userTypes.js";
 import { getDefaultAiModel, useAvailableAiModels } from "@/util/ai-models.js";
@@ -56,6 +57,7 @@ export const NotebookViewer: React.FC<NotebookViewerProps> = ({
     user: { sub: userId },
   } = useAuth();
   const { presentUsers, getUserInfo, getUserColor } = useUserRegistry();
+  const { focusCell: registryFocusCell } = useEditorRegistry();
   const { models } = useAvailableAiModels();
 
   const cellReferences = useQuery(queries.cellsWithIndices$);
@@ -319,11 +321,7 @@ export const NotebookViewer: React.FC<NotebookViewerProps> = ({
 
         // Position cursor in the next cell
         setTimeout(() => {
-          const editorRef = (window as any).cellEditorRefs?.get(nextCell.id);
-          if (editorRef) {
-            editorRef.setCursorPosition(cursorPosition);
-            editorRef.focus();
-          }
+          registryFocusCell(nextCell.id, cursorPosition);
         }, 50);
       } else {
         // At the last cell, create a new one with same cell type (but never raw)
@@ -348,13 +346,7 @@ export const NotebookViewer: React.FC<NotebookViewerProps> = ({
 
         // Position cursor in the previous cell
         setTimeout(() => {
-          const editorRef = (window as any).cellEditorRefs?.get(
-            previousCell.id
-          );
-          if (editorRef) {
-            editorRef.setCursorPosition(cursorPosition);
-            editorRef.focus();
-          }
+          registryFocusCell(previousCell.id, cursorPosition);
         }, 50);
       }
     },

--- a/src/components/notebook/cell/Cell.tsx
+++ b/src/components/notebook/cell/Cell.tsx
@@ -13,6 +13,7 @@ interface CellProps {
   onFocusNext?: () => void;
   onFocusPrevious?: () => void;
   autoFocus?: boolean;
+  scrollIntoView?: boolean;
   onFocus?: () => void;
   contextSelectionMode?: boolean;
 }
@@ -25,6 +26,7 @@ export const Cell: React.FC<CellProps> = ({
   onFocusNext,
   onFocusPrevious,
   autoFocus = false,
+  scrollIntoView = false,
   onFocus,
   contextSelectionMode = false,
 }) => {
@@ -46,6 +48,7 @@ export const Cell: React.FC<CellProps> = ({
           onFocusNext={onFocusNext}
           onFocusPrevious={onFocusPrevious}
           autoFocus={autoFocus}
+          scrollIntoView={scrollIntoView}
           onFocus={onFocus}
           contextSelectionMode={contextSelectionMode}
         />
@@ -58,6 +61,7 @@ export const Cell: React.FC<CellProps> = ({
           onFocusNext={onFocusNext}
           onFocusPrevious={onFocusPrevious}
           autoFocus={autoFocus}
+          scrollIntoView={scrollIntoView}
           onFocus={onFocus}
           contextSelectionMode={contextSelectionMode}
         />

--- a/src/components/notebook/cell/shared/CellContainer.tsx
+++ b/src/components/notebook/cell/shared/CellContainer.tsx
@@ -32,14 +32,11 @@ export const CellContainer = forwardRef<HTMLDivElement, CellContainerProps>(
       if (scrollIntoView && ref && typeof ref !== "function") {
         const element = ref.current;
         if (element) {
-          // Use a small delay to ensure the cell is fully rendered
-          setTimeout(() => {
-            element.scrollIntoView({
-              behavior: "smooth",
-              block: "center",
-              inline: "nearest",
-            });
-          }, 50);
+          element.scrollIntoView({
+            behavior: "smooth",
+            block: "center",
+            inline: "nearest",
+          });
         }
       }
     }, [scrollIntoView, ref]);

--- a/src/components/notebook/cell/shared/CellContainer.tsx
+++ b/src/components/notebook/cell/shared/CellContainer.tsx
@@ -1,10 +1,11 @@
 import { tables } from "@/schema";
-import { forwardRef, ReactNode } from "react";
+import { forwardRef, ReactNode, useEffect } from "react";
 import "./PresenceIndicators.css";
 
 interface CellContainerProps {
   cell: typeof tables.cells.Type;
   autoFocus?: boolean;
+  scrollIntoView?: boolean;
   contextSelectionMode?: boolean;
   onFocus?: () => void;
   children: ReactNode;
@@ -17,6 +18,7 @@ export const CellContainer = forwardRef<HTMLDivElement, CellContainerProps>(
     {
       cell,
       autoFocus = false,
+      scrollIntoView = false,
       contextSelectionMode = false,
       onFocus,
       children,
@@ -25,9 +27,27 @@ export const CellContainer = forwardRef<HTMLDivElement, CellContainerProps>(
     },
     ref
   ) => {
+    // Scroll into view when explicitly requested (for new cells)
+    useEffect(() => {
+      if (scrollIntoView && ref && typeof ref !== "function") {
+        const element = ref.current;
+        if (element) {
+          // Use a small delay to ensure the cell is fully rendered
+          setTimeout(() => {
+            element.scrollIntoView({
+              behavior: "smooth",
+              block: "center",
+              inline: "nearest",
+            });
+          }, 50);
+        }
+      }
+    }, [scrollIntoView, ref]);
+
     return (
       <div
         ref={ref}
+        data-cell-id={cell.id}
         className={`cell-container group relative pt-2 transition-all duration-200 ${
           autoFocus && !contextSelectionMode
             ? focusBgColor

--- a/src/components/notebook/cell/shared/Editor.tsx
+++ b/src/components/notebook/cell/shared/Editor.tsx
@@ -2,26 +2,31 @@ import { cn } from "@/lib/utils";
 import { KeyBinding } from "@codemirror/view";
 import { SupportedLanguage } from "@/types/misc.js";
 import { Maximize2, Minimize2 } from "lucide-react";
-import { useState, useEffect } from "react";
+import {
+  useState,
+  useEffect,
+  useRef,
+  forwardRef,
+  useImperativeHandle,
+} from "react";
 import { Button } from "@/components/ui/button";
-import { CodeMirrorEditor } from "@/components/notebook/codemirror/CodeMirrorEditor";
+import {
+  CodeMirrorEditor,
+  CodeMirrorEditorRef,
+} from "@/components/notebook/codemirror/CodeMirrorEditor";
 import { ErrorBoundary } from "react-error-boundary";
 
 const ErrorFallback = () => {
   return <div>Error rendering editor</div>;
 };
 
-export function Editor({
-  localSource,
-  handleSourceChange,
-  handleFocus,
-  onBlur,
-  language,
-  placeholder,
-  enableLineWrapping,
-  autoFocus,
-  keyMap,
-}: {
+export interface EditorRef {
+  focus: () => void;
+  setCursorPosition: (position: "start" | "end") => void;
+  getEditor: () => any;
+}
+
+interface EditorProps {
   localSource: string;
   handleSourceChange: (source: string) => void;
   onBlur: () => void;
@@ -31,100 +36,141 @@ export function Editor({
   enableLineWrapping?: boolean;
   autoFocus: boolean;
   keyMap: KeyBinding[];
-}) {
-  const [isMaximized, setIsMaximized] = useState(false);
-
-  // Handle escape key to close maximized editor
-  useEffect(() => {
-    const handleEscape = (e: KeyboardEvent) => {
-      if (e.key === "Escape" && isMaximized) {
-        setIsMaximized(false);
-      }
-    };
-
-    if (isMaximized) {
-      document.addEventListener("keydown", handleEscape);
-      return () => document.removeEventListener("keydown", handleEscape);
-    }
-  }, [isMaximized]);
-
-  // Handle clicking outside to close maximized editor
-  const handleBackdropClick = (e: React.MouseEvent) => {
-    if (e.target === e.currentTarget) {
-      setIsMaximized(false);
-    }
-  };
-
-  return (
-    <>
-      {/* Normal editor container */}
-      <div
-        className={cn("relative min-h-[1.5rem]", isMaximized && "opacity-20")}
-      >
-        <ErrorBoundary FallbackComponent={ErrorFallback}>
-          <CodeMirrorEditor
-            key="editor"
-            className="text-base sm:text-sm"
-            language={language}
-            placeholder={placeholder}
-            value={localSource}
-            onValueChange={handleSourceChange}
-            autoFocus={autoFocus && !isMaximized}
-            onFocus={handleFocus}
-            keyMap={keyMap}
-            onBlur={onBlur}
-            enableLineWrapping={enableLineWrapping}
-          />
-        </ErrorBoundary>
-        <Button
-          variant="ghost"
-          size="sm"
-          className="absolute top-1 right-1 h-6 w-6 p-1 sm:hidden"
-          onClick={() => setIsMaximized(true)}
-          aria-label="Maximize editor"
-        >
-          <Maximize2 className="h-3 w-3" />
-        </Button>
-      </div>
-
-      {/* Maximized editor overlay */}
-      {isMaximized && (
-        <div
-          className="fixed inset-0 z-50 bg-black/20 backdrop-blur-sm"
-          onClick={handleBackdropClick}
-        >
-          <div
-            className="bg-background absolute inset-0"
-            onClick={(e) => e.stopPropagation()}
-          >
-            <ErrorBoundary FallbackComponent={ErrorFallback}>
-              <CodeMirrorEditor
-                key="maximized-editor"
-                className="bg-background h-full text-base sm:text-sm"
-                maxHeight="100vh"
-                language={language}
-                placeholder={placeholder}
-                value={localSource}
-                onValueChange={handleSourceChange}
-                autoFocus={true}
-                onFocus={handleFocus}
-                keyMap={keyMap}
-                onBlur={onBlur}
-                enableLineWrapping={enableLineWrapping}
-              />
-            </ErrorBoundary>
-            <Button
-              variant="ghost"
-              size="sm"
-              className="absolute top-1 right-1 h-6 w-6 p-1"
-              onClick={() => setIsMaximized(false)}
-              aria-label="Minimize editor"
-            >
-              <Minimize2 className="h-3 w-3" />
-            </Button>
-          </div>
-        </div>
-      )}
-    </>
-  );
 }
+
+export const Editor = forwardRef<EditorRef, EditorProps>(
+  (
+    {
+      localSource,
+      handleSourceChange,
+      handleFocus,
+      onBlur,
+      language,
+      placeholder,
+      enableLineWrapping,
+      autoFocus,
+      keyMap,
+    },
+    ref
+  ) => {
+    const [isMaximized, setIsMaximized] = useState(false);
+    const normalEditorRef = useRef<CodeMirrorEditorRef>(null);
+    const maximizedEditorRef = useRef<CodeMirrorEditorRef>(null);
+
+    // Expose methods via ref - forward to the active editor
+    useImperativeHandle(
+      ref,
+      () => ({
+        focus: () => {
+          const activeEditor = isMaximized
+            ? maximizedEditorRef.current
+            : normalEditorRef.current;
+          activeEditor?.focus();
+        },
+        setCursorPosition: (position: "start" | "end") => {
+          const activeEditor = isMaximized
+            ? maximizedEditorRef.current
+            : normalEditorRef.current;
+          activeEditor?.setCursorPosition(position);
+        },
+        getEditor: () => {
+          const activeEditor = isMaximized
+            ? maximizedEditorRef.current
+            : normalEditorRef.current;
+          return activeEditor?.getEditor();
+        },
+      }),
+      [isMaximized]
+    );
+
+    // Handle escape key to close maximized editor
+    useEffect(() => {
+      const handleEscape = (e: KeyboardEvent) => {
+        if (e.key === "Escape" && isMaximized) {
+          setIsMaximized(false);
+        }
+      };
+
+      if (isMaximized) {
+        document.addEventListener("keydown", handleEscape);
+        return () => document.removeEventListener("keydown", handleEscape);
+      }
+    }, [isMaximized]);
+
+    return (
+      <>
+        {/* Normal Editor */}
+        <div
+          className={cn(
+            "relative transition-opacity duration-200",
+            isMaximized ? "pointer-events-none opacity-0" : "opacity-100"
+          )}
+        >
+          <ErrorBoundary FallbackComponent={ErrorFallback}>
+            <CodeMirrorEditor
+              ref={normalEditorRef}
+              key="editor"
+              className="text-base sm:text-sm"
+              language={language}
+              placeholder={placeholder}
+              value={localSource}
+              onValueChange={handleSourceChange}
+              autoFocus={autoFocus && !isMaximized}
+              onFocus={handleFocus}
+              onBlur={onBlur}
+              keyMap={keyMap}
+              enableLineWrapping={enableLineWrapping}
+            />
+          </ErrorBoundary>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="absolute top-1 right-1 h-6 w-6 p-0 opacity-0 transition-opacity group-hover:opacity-100"
+            onClick={() => setIsMaximized(true)}
+          >
+            <Maximize2 className="h-3 w-3" />
+          </Button>
+        </div>
+
+        {/* Maximized Editor Overlay */}
+        {isMaximized && (
+          <div className="bg-background fixed inset-0 z-50">
+            <div className="flex h-full flex-col">
+              <div className="flex items-center justify-between border-b p-2">
+                <span className="text-sm font-medium">Expanded Editor</span>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setIsMaximized(false)}
+                >
+                  <Minimize2 className="h-4 w-4" />
+                </Button>
+              </div>
+              <div className="flex-1 overflow-hidden">
+                <ErrorBoundary FallbackComponent={ErrorFallback}>
+                  <CodeMirrorEditor
+                    ref={maximizedEditorRef}
+                    key="maximized-editor"
+                    className="bg-background h-full text-base sm:text-sm"
+                    maxHeight="100vh"
+                    language={language}
+                    placeholder={placeholder}
+                    value={localSource}
+                    onValueChange={handleSourceChange}
+                    autoFocus={true}
+                    onFocus={handleFocus}
+                    onBlur={onBlur}
+                    keyMap={keyMap}
+                    enableLineWrapping={enableLineWrapping}
+                  />
+                </ErrorBoundary>
+              </div>
+            </div>
+          </div>
+        )}
+      </>
+    );
+  }
+);
+
+Editor.displayName = "Editor";

--- a/src/components/notebook/codemirror/baseExtensions.ts
+++ b/src/components/notebook/codemirror/baseExtensions.ts
@@ -33,19 +33,9 @@ const customStyles = EditorView.theme({
       padding: "0.75rem 0.5rem",
     },
   },
-  // Reset cursor animation on focus for better visibility
-  "&.cm-focused .cm-cursor": {
-    animation: "steps(1) cm-blink 1.2s infinite",
-    animationDelay: "0s !important",
-  },
-  // Ensure cursor is visible immediately on focus
-  "&.cm-focused .cm-cursor-primary": {
-    opacity: 1,
-  },
-  // Define the blink animation
-  "@keyframes cm-blink": {
-    "0%, 50%": { opacity: 1 },
-    "51%, 100%": { opacity: 0 },
+  // Slightly thicker cursor
+  ".cm-cursor": {
+    borderLeftWidth: "2px",
   },
 });
 

--- a/src/hooks/useCellKeyboardNavigation.ts
+++ b/src/hooks/useCellKeyboardNavigation.ts
@@ -2,8 +2,8 @@ import { KeyBinding } from "@codemirror/view";
 import { useCallback, useMemo } from "react";
 
 interface CellKeyboardNavigationOptions {
-  onFocusNext?: () => void;
-  onFocusPrevious?: () => void;
+  onFocusNext?: (cursorPosition?: "start" | "end") => void;
+  onFocusPrevious?: (cursorPosition?: "start" | "end") => void;
   onExecute?: () => void;
   onUpdateSource?: () => void;
   onDeleteCell?: () => void;
@@ -33,7 +33,7 @@ export const useCellKeyboardNavigation = ({
         run: () => {
           onUpdateSource?.();
           onExecute?.();
-          onFocusNext?.();
+          onFocusNext?.("start");
           return true;
         },
       },
@@ -45,12 +45,11 @@ export const useCellKeyboardNavigation = ({
           const cursorPos = selection.main.head;
           const docLength = state.doc.length;
 
+          // Navigate to next cell when at very end of document
           if (cursorPos === docLength) {
-            onFocusNext?.();
-            // Prevent CodeMirror from handling
+            onFocusNext?.("start");
             return true;
           }
-          // Pass on to CodeMirror
           return false;
         },
       },
@@ -61,12 +60,11 @@ export const useCellKeyboardNavigation = ({
           const { selection } = state;
           const cursorPos = selection.main.head;
 
+          // Navigate to previous cell when at very start of document
           if (cursorPos === 0) {
-            onFocusPrevious?.();
-            // Prevent CodeMirror from handling
+            onFocusPrevious?.("end");
             return true;
           }
-          // Pass on to CodeMirror
           return false;
         },
       },
@@ -137,7 +135,7 @@ export const useCellKeyboardNavigation = ({
             if (onFocusPrevious) {
               e.preventDefault();
               onUpdateSource?.();
-              onFocusPrevious();
+              onFocusPrevious("end");
               return;
             }
           } else {
@@ -166,7 +164,7 @@ export const useCellKeyboardNavigation = ({
             if (onFocusNext) {
               e.preventDefault();
               onUpdateSource?.();
-              onFocusNext();
+              onFocusNext("start");
               return;
             }
           } else {
@@ -190,7 +188,7 @@ export const useCellKeyboardNavigation = ({
         e.preventDefault();
         onUpdateSource?.();
         onExecute?.();
-        onFocusNext?.(); // Move to next cell (or create new if at end)
+        onFocusNext?.("start"); // Move to next cell (or create new if at end)
       }
     },
     [onFocusNext, onFocusPrevious, onExecute, onUpdateSource, onDeleteCell]

--- a/src/hooks/useEditorRegistry.ts
+++ b/src/hooks/useEditorRegistry.ts
@@ -53,7 +53,7 @@ export const useEditorRegistry = () => {
               inline: "nearest",
             });
           }
-        }, 0);
+        }, 100);
       }
     },
     []

--- a/src/hooks/useEditorRegistry.ts
+++ b/src/hooks/useEditorRegistry.ts
@@ -42,18 +42,16 @@ export const useEditorRegistry = () => {
         editorRef.setCursorPosition(cursorPosition);
 
         // Scroll cell into view for arrow key navigation
-        setTimeout(() => {
-          const cellElement = document.querySelector(
-            `[data-cell-id="${cellId}"]`
-          );
-          if (cellElement) {
-            cellElement.scrollIntoView({
-              behavior: "smooth",
-              block: "center",
-              inline: "nearest",
-            });
-          }
-        }, 100);
+        const cellElement = document.querySelector(
+          `[data-cell-id="${cellId}"]`
+        );
+        if (cellElement) {
+          cellElement.scrollIntoView({
+            behavior: "smooth",
+            block: "center",
+            inline: "nearest",
+          });
+        }
       }
     },
     []

--- a/src/hooks/useEditorRegistry.ts
+++ b/src/hooks/useEditorRegistry.ts
@@ -1,0 +1,75 @@
+import { useCallback, useRef } from "react";
+import { useStore } from "@livestore/react";
+import { signal } from "@livestore/livestore";
+import type { CodeMirrorEditorRef } from "@/components/notebook/codemirror/CodeMirrorEditor";
+
+// Create a signal to store editor refs by cell ID
+const editorRefsSignal = signal(
+  new Map<string, CodeMirrorEditorRef>(),
+  { label: "editorRefs" }
+);
+
+export const useEditorRegistry = () => {
+  const { store } = useStore();
+  const editorRefs = useRef<Map<string, CodeMirrorEditorRef>>(new Map());
+
+  const registerEditor = useCallback(
+    (cellId: string, editorRef: CodeMirrorEditorRef) => {
+      editorRefs.current.set(cellId, editorRef);
+
+      // Update the signal with new map
+      const newMap = new Map(editorRefs.current);
+      store.setSignal(editorRefsSignal, newMap);
+    },
+    [store]
+  );
+
+  const unregisterEditor = useCallback(
+    (cellId: string) => {
+      editorRefs.current.delete(cellId);
+
+      // Update the signal with new map
+      const newMap = new Map(editorRefs.current);
+      store.setSignal(editorRefsSignal, newMap);
+    },
+    [store]
+  );
+
+  const focusCell = useCallback(
+    (cellId: string, cursorPosition: "start" | "end" = "start") => {
+      const editorRef = editorRefs.current.get(cellId);
+      if (editorRef) {
+        editorRef.focus();
+        editorRef.setCursorPosition(cursorPosition);
+      }
+    },
+    []
+  );
+
+  const setCellCursorPosition = useCallback(
+    (cellId: string, position: "start" | "end") => {
+      const editorRef = editorRefs.current.get(cellId);
+      if (editorRef) {
+        editorRef.setCursorPosition(position);
+      }
+    },
+    []
+  );
+
+  const hasEditor = useCallback((cellId: string) => {
+    return editorRefs.current.has(cellId);
+  }, []);
+
+  const getEditor = useCallback((cellId: string) => {
+    return editorRefs.current.get(cellId);
+  }, []);
+
+  return {
+    registerEditor,
+    unregisterEditor,
+    focusCell,
+    setCellCursorPosition,
+    hasEditor,
+    getEditor,
+  };
+};

--- a/src/hooks/useEditorRegistry.ts
+++ b/src/hooks/useEditorRegistry.ts
@@ -4,10 +4,9 @@ import { signal } from "@livestore/livestore";
 import type { CodeMirrorEditorRef } from "@/components/notebook/codemirror/CodeMirrorEditor";
 
 // Create a signal to store editor refs by cell ID
-const editorRefsSignal = signal(
-  new Map<string, CodeMirrorEditorRef>(),
-  { label: "editorRefs" }
-);
+const editorRefsSignal = signal(new Map<string, CodeMirrorEditorRef>(), {
+  label: "editorRefs",
+});
 
 export const useEditorRegistry = () => {
   const { store } = useStore();
@@ -41,6 +40,20 @@ export const useEditorRegistry = () => {
       if (editorRef) {
         editorRef.focus();
         editorRef.setCursorPosition(cursorPosition);
+
+        // Scroll cell into view for arrow key navigation
+        setTimeout(() => {
+          const cellElement = document.querySelector(
+            `[data-cell-id="${cellId}"]`
+          );
+          if (cellElement) {
+            cellElement.scrollIntoView({
+              behavior: "smooth",
+              block: "center",
+              inline: "nearest",
+            });
+          }
+        }, 0);
       }
     },
     []


### PR DESCRIPTION
Fixes cell navigation issues: new cells now scroll into view, arrow keys work properly at cell boundaries, up arrow positions cursor at end of previous cell.

Key changes:
- Fixed new cell scroll behavior (only scrolls for new cells, not clicked cells)
- Simplified arrow key navigation with better boundary detection
- Added proper cursor positioning between cells via CodeMirror refs
- Replaced hacky global state with clean LiveStore signals approach
- Slightly thicker cursor (2px) for better visibility

Navigation now works like a fluid paper document. Down arrow at notebook bottom creates new cells. Large editor clicking preserved without unwanted scrolling.