### PR TITLE
perf: optimize cell focus rendering by eliminating signal prop drilling

### DIFF
--- a/src/components/notebook/CellList.tsx
+++ b/src/components/notebook/CellList.tsx
@@ -1,13 +1,13 @@
 import React from "react";
 import { ErrorBoundary } from "react-error-boundary";
+import { useQuery } from "@livestore/react";
 import { Cell } from "./cell/Cell.js";
 import { CellBetweener } from "./cell/CellBetweener.js";
 import { CellReference } from "@/schema";
-import type { SignalDef } from "@livestore/livestore";
+import { focusedCellSignal$ } from "./signals/focus.js";
 
 interface CellListProps {
   cellReferences: readonly CellReference[];
-  focusedCellSignal$: SignalDef<string | null>;
   onAddCell: (
     cellId?: string,
     cellType?: "code" | "markdown" | "sql" | "ai",
@@ -28,7 +28,6 @@ interface CellListProps {
 
 export const CellList: React.FC<CellListProps> = ({
   cellReferences,
-  focusedCellSignal$,
   onAddCell,
   onDeleteCell,
   onMoveUp,
@@ -39,6 +38,7 @@ export const CellList: React.FC<CellListProps> = ({
   contextSelectionMode = false,
   // Virtualization props ignored
 }) => {
+  const focusedCellId = useQuery(focusedCellSignal$);
   return (
     <div style={{ paddingLeft: "1rem" }}>
       {cellReferences.map((cellReference, index) => (
@@ -53,13 +53,13 @@ export const CellList: React.FC<CellListProps> = ({
             )}
             <Cell
               cellId={cellReference.id}
+              isFocused={cellReference.id === focusedCellId}
               onDeleteCell={() => onDeleteCell(cellReference.id)}
               onMoveUp={() => onMoveUp(cellReference.id)}
               onMoveDown={() => onMoveDown(cellReference.id)}
               onFocusNext={() => onFocusNext(cellReference.id)}
               onFocusPrevious={() => onFocusPrevious(cellReference.id)}
               onFocus={() => onFocus(cellReference.id)}
-              focusedCellSignal$={focusedCellSignal$}
               contextSelectionMode={contextSelectionMode}
             />
             <CellBetweener

--- a/src/components/notebook/NotebookViewer.tsx
+++ b/src/components/notebook/NotebookViewer.tsx
@@ -1,5 +1,5 @@
 // import { toast } from "sonner";
-import { queryDb, signal } from "@livestore/livestore";
+import { queryDb } from "@livestore/livestore";
 import { useQuery, useStore } from "@livestore/react";
 import {
   events,

--- a/src/components/notebook/NotebookViewer.tsx
+++ b/src/components/notebook/NotebookViewer.tsx
@@ -28,14 +28,7 @@ import { Bug, BugOff, Filter, X } from "lucide-react";
 import { UserProfile } from "../auth/UserProfile.js";
 import { RuntimeHealthIndicatorButton } from "./RuntimeHealthIndicatorButton.js";
 import { RuntimeHelper } from "./RuntimeHelper.js";
-
-// Global focus signals (not persisted to LiveStore)
-const focusedCellSignal$ = signal<string | null>(null, {
-  label: "focusedCellId$",
-});
-const hasManuallyFocused$ = signal<boolean>(false, {
-  label: "hasManuallyFocused$",
-});
+import { focusedCellSignal$, hasManuallyFocused$ } from "./signals/focus.js";
 
 // Lazy import DebugPanel only in development
 const LazyDebugPanel = React.lazy(() =>
@@ -551,7 +544,6 @@ export const NotebookViewer: React.FC<NotebookViewerProps> = ({
                 <ErrorBoundary fallback={<div>Error rendering cell list</div>}>
                   <CellList
                     cellReferences={cellReferences}
-                    focusedCellSignal$={focusedCellSignal$}
                     onAddCell={addCell}
                     onDeleteCell={deleteCell}
                     onMoveUp={(cellId) => moveCell(cellId, "up")}

--- a/src/components/notebook/cell/Cell.tsx
+++ b/src/components/notebook/cell/Cell.tsx
@@ -2,36 +2,33 @@ import { queries } from "@/schema";
 import React from "react";
 import { ErrorBoundary } from "react-error-boundary";
 import { useQuery } from "@livestore/react";
-import type { SignalDef } from "@livestore/livestore";
 import { ExecutableCell } from "./ExecutableCell.js";
 import { MarkdownCell } from "./MarkdownCell.js";
 
 interface CellProps {
   cellId: string;
+  isFocused: boolean;
   onDeleteCell: () => void;
   onMoveUp: () => void;
   onMoveDown: () => void;
   onFocusNext?: () => void;
   onFocusPrevious?: () => void;
-  focusedCellSignal$: SignalDef<string | null>;
   onFocus?: () => void;
   contextSelectionMode?: boolean;
 }
 
 export const Cell: React.FC<CellProps> = ({
   cellId,
+  isFocused,
   onDeleteCell,
   onMoveUp,
   onMoveDown,
   onFocusNext,
   onFocusPrevious,
-  focusedCellSignal$,
   onFocus,
   contextSelectionMode = false,
 }) => {
   const cell = useQuery(queries.cellQuery.byId(cellId));
-  const focusedCellId = useQuery(focusedCellSignal$);
-  const autoFocus = cellId === focusedCellId;
 
   if (!cell) {
     console.warn("Asked to render a cell that does not exist");
@@ -48,7 +45,7 @@ export const Cell: React.FC<CellProps> = ({
           onMoveDown={onMoveDown}
           onFocusNext={onFocusNext}
           onFocusPrevious={onFocusPrevious}
-          autoFocus={autoFocus}
+          autoFocus={isFocused}
           onFocus={onFocus}
           contextSelectionMode={contextSelectionMode}
         />
@@ -60,7 +57,7 @@ export const Cell: React.FC<CellProps> = ({
           onMoveDown={onMoveDown}
           onFocusNext={onFocusNext}
           onFocusPrevious={onFocusPrevious}
-          autoFocus={autoFocus}
+          autoFocus={isFocused}
           onFocus={onFocus}
           contextSelectionMode={contextSelectionMode}
         />

--- a/src/components/notebook/signals/focus.ts
+++ b/src/components/notebook/signals/focus.ts
@@ -1,0 +1,16 @@
+import { signal } from "@livestore/livestore";
+
+/**
+ * Signal tracking which cell is currently focused
+ */
+export const focusedCellSignal$ = signal<string | null>(null, {
+  label: "focusedCellId$",
+});
+
+/**
+ * Signal tracking whether the user has manually focused a cell
+ * Used to determine if we should auto-focus the first cell
+ */
+export const hasManuallyFocused$ = signal<boolean>(false, {
+  label: "hasManuallyFocused$",
+});


### PR DESCRIPTION
## Performance Optimization

This PR eliminates unnecessary re-renders when cell focus changes by optimizing how focus state flows through the component tree.

### Changes

- **Move focus signals to dedicated module**: Created  for centralized focus state management
- **Eliminate signal prop drilling**: Components now import focus signals directly instead of receiving them as props  
- **Computed boolean props**:  components now receive  instead of subscribing to signals directly