### PR TITLE
take out cell movement

### DIFF
--- a/src/components/notebook/CellList.tsx
+++ b/src/components/notebook/CellList.tsx
@@ -14,8 +14,6 @@ interface CellListProps {
     position?: "before" | "after"
   ) => void;
   onDeleteCell: (cellId: string) => void;
-  onMoveUp: (cellId: string) => void;
-  onMoveDown: (cellId: string) => void;
   onFocusNext: (cellId: string) => void;
   onFocusPrevious: (cellId: string) => void;
   onFocus: (cellId: string) => void;
@@ -30,8 +28,6 @@ export const CellList: React.FC<CellListProps> = ({
   cellReferences,
   onAddCell,
   onDeleteCell,
-  onMoveUp,
-  onMoveDown,
   onFocusNext,
   onFocusPrevious,
   onFocus,
@@ -55,8 +51,6 @@ export const CellList: React.FC<CellListProps> = ({
               cellId={cellReference.id}
               isFocused={cellReference.id === focusedCellId}
               onDeleteCell={() => onDeleteCell(cellReference.id)}
-              onMoveUp={() => onMoveUp(cellReference.id)}
-              onMoveDown={() => onMoveDown(cellReference.id)}
               onFocusNext={() => onFocusNext(cellReference.id)}
               onFocusPrevious={() => onFocusPrevious(cellReference.id)}
               onFocus={() => onFocus(cellReference.id)}

--- a/src/components/notebook/NotebookViewer.tsx
+++ b/src/components/notebook/NotebookViewer.tsx
@@ -5,7 +5,6 @@ import {
   events,
   tables,
   createCellBetween,
-  moveCellBetweenWithRebalancing,
   queries,
   CellReference,
 } from "@/schema";
@@ -182,107 +181,6 @@ export const NotebookViewer: React.FC<NotebookViewerProps> = ({
       );
     },
     [store, userId]
-  );
-
-  // Track if a move operation is in progress to prevent race conditions
-  const movingRef = useRef(false);
-
-  const moveCell = useCallback(
-    (cellId: string, direction: "up" | "down") => {
-      // Prevent concurrent moves
-      if (movingRef.current) {
-        return;
-      }
-      movingRef.current = true;
-
-      // Cells are already sorted by fractionalIndex from the database query
-      const currentIndex = cellReferences.findIndex((c) => c.id === cellId);
-      if (currentIndex === -1) {
-        return;
-      }
-
-      const currentCell = cellReferences[currentIndex];
-      if (!currentCell.fractionalIndex) {
-        return;
-      }
-
-      // Check boundaries
-      if (direction === "up" && currentIndex === 0) {
-        return;
-      }
-      if (direction === "down" && currentIndex === cellReferences.length - 1) {
-        return;
-      }
-
-      // Check for duplicate fractional indices
-      const duplicates = cellReferences.filter(
-        (c) =>
-          c.fractionalIndex === currentCell.fractionalIndex &&
-          c.id !== currentCell.id
-      );
-      if (duplicates.length > 0) {
-        // Skip move if duplicate indices exist to prevent ordering issues
-        // TODO: Figure out what to do here
-        return;
-      }
-
-      // Determine the before and after cells based on direction
-      // With fractional indexing, we place the cell between its new neighbors
-      let cellBefore: CellReference | null = null;
-      let cellAfter: CellReference | null = null;
-
-      if (direction === "up") {
-        // Moving up: place between the cell 2 positions up and 1 position up
-        cellBefore =
-          currentIndex >= 2 ? cellReferences[currentIndex - 2] : null;
-        cellAfter = cellReferences[currentIndex - 1];
-      } else {
-        // Moving down: place between the cell 1 position down and 2 positions down
-        cellBefore = cellReferences[currentIndex + 1];
-        cellAfter =
-          currentIndex < cellReferences.length - 2
-            ? cellReferences[currentIndex + 2]
-            : null;
-      }
-
-      // Use moveCellBetween to calculate the new position
-
-      // Verify the ordering makes sense
-      if (
-        cellBefore &&
-        cellAfter &&
-        cellBefore.fractionalIndex &&
-        cellAfter.fractionalIndex
-      ) {
-        const correctOrder =
-          cellBefore.fractionalIndex < cellAfter.fractionalIndex;
-        if (!correctOrder) {
-          // Invalid order detected - skip the move
-          return;
-        }
-      }
-
-      const moveResult = moveCellBetweenWithRebalancing(
-        currentCell,
-        cellBefore,
-        cellAfter,
-        cellReferences, // Pass current cell state for rebalancing context
-        userId
-      );
-
-      if (moveResult.moved) {
-        // Commit all events (may include automatic rebalancing)
-        moveResult.events.forEach((event) => store.commit(event));
-      } else {
-        // Cell already in target position or invalid move
-      }
-
-      // Reset the moving flag after a short delay to allow for database updates
-      setTimeout(() => {
-        movingRef.current = false;
-      }, 100);
-    },
-    [cellReferences, store, userId]
   );
 
   const focusCell = useCallback(
@@ -546,8 +444,6 @@ export const NotebookViewer: React.FC<NotebookViewerProps> = ({
                     cellReferences={cellReferences}
                     onAddCell={addCell}
                     onDeleteCell={deleteCell}
-                    onMoveUp={(cellId) => moveCell(cellId, "up")}
-                    onMoveDown={(cellId) => moveCell(cellId, "down")}
                     onFocusNext={focusNextCell}
                     onFocusPrevious={focusPreviousCell}
                     onFocus={focusCell}

--- a/src/components/notebook/cell/Cell.tsx
+++ b/src/components/notebook/cell/Cell.tsx
@@ -9,8 +9,6 @@ interface CellProps {
   cellId: string;
   isFocused: boolean;
   onDeleteCell: () => void;
-  onMoveUp: () => void;
-  onMoveDown: () => void;
   onFocusNext?: () => void;
   onFocusPrevious?: () => void;
   onFocus?: () => void;
@@ -21,8 +19,6 @@ export const Cell: React.FC<CellProps> = ({
   cellId,
   isFocused,
   onDeleteCell,
-  onMoveUp,
-  onMoveDown,
   onFocusNext,
   onFocusPrevious,
   onFocus,
@@ -41,8 +37,6 @@ export const Cell: React.FC<CellProps> = ({
         <MarkdownCell
           cell={cell}
           onDeleteCell={onDeleteCell}
-          onMoveUp={onMoveUp}
-          onMoveDown={onMoveDown}
           onFocusNext={onFocusNext}
           onFocusPrevious={onFocusPrevious}
           autoFocus={isFocused}
@@ -53,8 +47,6 @@ export const Cell: React.FC<CellProps> = ({
         <ExecutableCell
           cell={cell}
           onDeleteCell={onDeleteCell}
-          onMoveUp={onMoveUp}
-          onMoveDown={onMoveDown}
           onFocusNext={onFocusNext}
           onFocusPrevious={onFocusPrevious}
           autoFocus={isFocused}

--- a/src/components/notebook/cell/ExecutableCell.tsx
+++ b/src/components/notebook/cell/ExecutableCell.tsx
@@ -57,8 +57,6 @@ const getCellStyling = (cellType: "code" | "sql" | "ai") => {
 interface ExecutableCellProps {
   cell: typeof tables.cells.Type;
   onDeleteCell: () => void;
-  onMoveUp: () => void;
-  onMoveDown: () => void;
   onFocusNext?: () => void;
   onFocusPrevious?: () => void;
   autoFocus?: boolean;
@@ -69,8 +67,6 @@ interface ExecutableCellProps {
 export const ExecutableCell: React.FC<ExecutableCellProps> = ({
   cell,
   onDeleteCell,
-  onMoveUp,
-  onMoveDown,
   onFocusNext,
   onFocusPrevious,
   autoFocus = false,
@@ -323,8 +319,6 @@ export const ExecutableCell: React.FC<ExecutableCellProps> = ({
           sourceVisible={cell.sourceVisible}
           aiContextVisible={cell.aiContextVisible}
           contextSelectionMode={contextSelectionMode}
-          onMoveUp={onMoveUp}
-          onMoveDown={onMoveDown}
           onDeleteCell={onDeleteCell}
           onClearOutputs={clearCellOutputs}
           hasOutputs={hasOutputs}

--- a/src/components/notebook/cell/MarkdownCell.tsx
+++ b/src/components/notebook/cell/MarkdownCell.tsx
@@ -29,8 +29,6 @@ type CellType = typeof tables.cells.Type;
 interface MarkdownCellProps {
   cell: CellType;
   onDeleteCell: () => void;
-  onMoveUp: () => void;
-  onMoveDown: () => void;
   onFocusNext?: () => void;
   onFocusPrevious?: () => void;
   autoFocus?: boolean;
@@ -47,8 +45,6 @@ const MarkdownRenderer = React.lazy(() =>
 export const MarkdownCell: React.FC<MarkdownCellProps> = ({
   cell,
   onDeleteCell,
-  onMoveUp,
-  onMoveDown,
   onFocusNext,
   onFocusPrevious,
   autoFocus = false,
@@ -240,8 +236,6 @@ export const MarkdownCell: React.FC<MarkdownCellProps> = ({
           sourceVisible={cell.sourceVisible}
           aiContextVisible={cell.aiContextVisible}
           contextSelectionMode={contextSelectionMode}
-          onMoveUp={onMoveUp}
-          onMoveDown={onMoveDown}
           onDeleteCell={onDeleteCell}
           onClearOutputs={clearCellOutputs}
           hasOutputs={hasOutputs}

--- a/src/components/notebook/cell/shared/CellControls.tsx
+++ b/src/components/notebook/cell/shared/CellControls.tsx
@@ -11,8 +11,6 @@ import {
   ChevronDown,
   Eye,
   EyeOff,
-  ArrowUp,
-  ArrowDown,
   X,
   MoreVertical,
   Eraser,
@@ -22,8 +20,6 @@ interface CellControlsProps {
   sourceVisible: boolean;
   aiContextVisible: boolean;
   contextSelectionMode?: boolean;
-  onMoveUp: () => void;
-  onMoveDown: () => void;
   onDeleteCell: () => void;
   onClearOutputs: () => void;
   hasOutputs: boolean;
@@ -36,8 +32,6 @@ export const CellControls: React.FC<CellControlsProps> = ({
   sourceVisible,
   aiContextVisible,
   contextSelectionMode = false,
-  onMoveUp,
-  onMoveDown,
   onDeleteCell,
   onClearOutputs,
   hasOutputs,
@@ -92,24 +86,6 @@ export const CellControls: React.FC<CellControlsProps> = ({
       <div className="desktop-controls hidden items-center gap-0.5 sm:flex">
         {/* Separator */}
         <div className="bg-border/50 mx-1 h-4 w-px" />
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={onMoveUp}
-          className="hover:bg-muted/80 h-7 w-7 p-0"
-          title="Move cell up"
-        >
-          <ArrowUp className="h-3 w-3" />
-        </Button>
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={onMoveDown}
-          className="hover:bg-muted/80 h-7 w-7 p-0"
-          title="Move cell down"
-        >
-          <ArrowDown className="h-3 w-3" />
-        </Button>
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button


### PR DESCRIPTION
The current implementation makes it hard to tone down how data flows between NotebookViewer, CellList, and Cells in addition to not being our ideal (moving cells should be done with drag and drop).