### PR TITLE
refactor: remove unused legacy virtualization props from CellList

### DIFF
--- a/src/components/notebook/CellList.tsx
+++ b/src/components/notebook/CellList.tsx
@@ -17,10 +17,6 @@ interface CellListProps {
   onFocusNext: (cellId: string) => void;
   onFocusPrevious: (cellId: string) => void;
   onFocus: (cellId: string) => void;
-  // Legacy virtualization props (ignored but kept for compatibility)
-  itemHeight?: number;
-  overscan?: number;
-  threshold?: number;
 }
 
 export const CellList: React.FC<CellListProps> = ({
@@ -30,7 +26,6 @@ export const CellList: React.FC<CellListProps> = ({
   onFocusNext,
   onFocusPrevious,
   onFocus,
-  // Virtualization props ignored
 }) => {
   const focusedCellId = useQuery(focusedCellSignal$);
   return (


### PR DESCRIPTION
# Remove Legacy Virtualization Props

Simple cleanup to remove unused legacy virtualization properties from the CellList interface.

## Changes

**Removed unused props from `CellListProps`:**
- `itemHeight?: number`
- `overscan?: number` 
- `threshold?: number`

**Cleaned up:**
- Removed related comments about virtualization being ignored
- Removed unused destructuring in component implementation

## Context

These props were leftover from an earlier virtualization implementation that is no longer in use. They were:

- Never actually used in the component logic
- Never passed by any calling code
- Just adding noise to the interface