### PR TITLE
perf: eliminate focus change re-render cascade with React.memo

### DIFF
--- a/src/components/notebook/cell/Cell.tsx
+++ b/src/components/notebook/cell/Cell.tsx
@@ -1,5 +1,5 @@
 import { queries } from "@/schema";
-import React from "react";
+import React, { memo } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 import { useQuery } from "@livestore/react";
 import { ExecutableCell } from "./ExecutableCell.js";
@@ -11,33 +11,31 @@ interface CellProps {
   contextSelectionMode: boolean;
 }
 
-export const Cell: React.FC<CellProps> = ({
-  cellId,
-  isFocused,
-  contextSelectionMode,
-}) => {
-  const cell = useQuery(queries.cellQuery.byId(cellId));
+export const Cell: React.FC<CellProps> = memo(
+  ({ cellId, isFocused, contextSelectionMode }) => {
+    const cell = useQuery(queries.cellQuery.byId(cellId));
 
-  if (!cell) {
-    console.warn("Asked to render a cell that does not exist");
-    return null;
+    if (!cell) {
+      console.warn("Asked to render a cell that does not exist");
+      return null;
+    }
+
+    return (
+      <ErrorBoundary fallback={<div>Error rendering cell</div>}>
+        {cell.cellType === "markdown" ? (
+          <MarkdownCell
+            cell={cell}
+            autoFocus={isFocused}
+            contextSelectionMode={contextSelectionMode}
+          />
+        ) : (
+          <ExecutableCell
+            cell={cell}
+            autoFocus={isFocused}
+            contextSelectionMode={contextSelectionMode}
+          />
+        )}
+      </ErrorBoundary>
+    );
   }
-
-  return (
-    <ErrorBoundary fallback={<div>Error rendering cell</div>}>
-      {cell.cellType === "markdown" ? (
-        <MarkdownCell
-          cell={cell}
-          autoFocus={isFocused}
-          contextSelectionMode={contextSelectionMode}
-        />
-      ) : (
-        <ExecutableCell
-          cell={cell}
-          autoFocus={isFocused}
-          contextSelectionMode={contextSelectionMode}
-        />
-      )}
-    </ErrorBoundary>
-  );
-};
+);

--- a/src/components/notebook/cell/CellBetweener.tsx
+++ b/src/components/notebook/cell/CellBetweener.tsx
@@ -2,8 +2,9 @@ import { Button } from "@/components/ui/button";
 import { CellReference } from "@/schema";
 import { Plus } from "lucide-react";
 import { useAddCell } from "@/hooks/useAddCell.js";
+import { memo } from "react";
 
-export function CellBetweener({
+export const CellBetweener = memo(function CellBetweener({
   cell,
   position = "after",
 }: {
@@ -11,6 +12,7 @@ export function CellBetweener({
   position: "before" | "after";
 }) {
   const { addCell } = useAddCell();
+
   return (
     <div className="group relative flex h-6 w-full items-center justify-center">
       <div className="absolute -left-[13px] z-10 flex h-px w-full items-center bg-transparent has-hover:bg-neutral-500">
@@ -31,4 +33,4 @@ export function CellBetweener({
       </div>
     </div>
   );
-}
+});


### PR DESCRIPTION
## Performance Optimization: Focus Change Re-render Cascade

Eliminates unnecessary re-renders when switching between cells by adding strategic `React.memo` optimization.

### Problem
- **Focus changes triggered ALL cells to re-render** (even those that didn't change focus)
- **All CellBetweener components re-rendered** on every focus change
- Root cause: `CellList` re-renders on focus change, creating new function props for all cells

### Solution
- **Added `React.memo` to `Cell` component** - only re-renders when props actually change
- **Added `React.memo` to `CellBetweener` component** - prevents unnecessary re-renders
- Components now only re-render when their actual state changes

### Performance Impact
**Before**: ALL cells + betweeners re-render on focus change (~10+ unnecessary re-renders)
**After**: Only 2 cells re-render (the ones actually changing focus state)

This is especially beneficial for notebooks with many cells, where focus changes would previously trigger massive component cascades.

### Technical Details
- Uses `React.memo` default shallow comparison (sufficient for our props)
- Maintains all existing functionality and prop interfaces
- No breaking changes or behavioral differences

### Testing Results
Verified with debug logging showing dramatic reduction in re-renders:
- Focus change from cell A → cell B: Only 2 components re-render instead of 10+
- Typing in focused cell: Still just 1 re-render (no regression)

This builds on the previous keystroke performance fix to create a highly optimized notebook rendering experience.