### PR TITLE
Vite fixes

### DIFF
--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -273,7 +273,7 @@ export const App: React.FC = () => {
     const checkInterval = setInterval(() => {
       if (isLoadingScreenVisible()) {
         // Check if React has rendered content
-        const rootElement = document.getElementById("root");
+        const rootElement = document.getElementById("react-app");
         const hasContent = rootElement && rootElement.children.length > 0;
 
         if (hasContent) {

--- a/vite-plugins/inject-loading-screen.ts
+++ b/vite-plugins/inject-loading-screen.ts
@@ -6,6 +6,10 @@ export function injectLoadingScreen(): Plugin {
     transformIndexHtml: {
       order: "pre",
       handler(html) {
+        if (html.includes('name="livestore-devtools"')) {
+          return html;
+        }
+
         // Static HTML loading screen that matches NotebookLoadingScreen styling
         const loadingHTML = `
           <div id="static-loading-screen" style="


### PR DESCRIPTION
* Bring back livestore dev tools by not injecting our loading screen on its page
* Allow vite to restart itself by keeping the iframe server continuous