### PR TITLE
Implement the remaining CRUD endpoints for api keys

### DIFF
--- a/backend/api_keys.ts
+++ b/backend/api_keys.ts
@@ -23,6 +23,7 @@ import {
   SimpleHandler,
 } from "./types";
 import { extractBearerToken, parseToken } from "./auth";
+import { pathToRegexp } from "path-to-regexp";
 
 import apiKeyProvider from "./local_extension/api_key_provider";
 
@@ -98,6 +99,24 @@ const validateCreateApiKeyRequest = (
   return true;
 };
 
+const validateRevokeApiKeyRequest = (
+  body: unknown
+): body is { revoked: boolean } => {
+  if (typeof body !== "object" || body === null) {
+    throw new RuntError(ErrorType.InvalidRequest, {
+      message: "Request body must be an object",
+    });
+  }
+  const request = body as Record<string, unknown>;
+
+  if (typeof request.revoked !== "boolean" || request.revoked !== true) {
+    throw new RuntError(ErrorType.InvalidRequest, {
+      message: "invalid revoked value",
+    });
+  }
+  return true;
+};
+
 const parseJsonBody = async <T>(
   request: WorkerRequest<unknown, IncomingRequestCfProperties<unknown>>
 ): Promise<T> => {
@@ -112,11 +131,11 @@ const parseJsonBody = async <T>(
   }
 };
 
-const createApiKeyHandler: ExportedHandlerFetchHandler<Env> = async (
+const createAuthenticatedContext = async (
   request: WorkerRequest<unknown, IncomingRequestCfProperties<unknown>>,
   env: Env,
   ctx: ExecutionContext
-): Promise<WorkerResponse> => {
+): Promise<AuthenticatedProviderContext> => {
   let passport: Passport;
   const authToken = extractBearerToken(request);
   if (!authToken) {
@@ -137,9 +156,6 @@ const createApiKeyHandler: ExportedHandlerFetchHandler<Env> = async (
     }
     throw new RuntError(ErrorType.AuthTokenInvalid, { cause: error as Error });
   }
-
-  const body = await parseJsonBody<CreateApiKeyRequest>(request);
-  validateCreateApiKeyRequest(body);
   const context: AuthenticatedProviderContext = {
     request,
     env,
@@ -147,10 +163,116 @@ const createApiKeyHandler: ExportedHandlerFetchHandler<Env> = async (
     bearerToken: authToken,
     passport,
   };
-  const result = await apiKeyProvider!.createApiKey(context, body);
+  return context;
+};
+
+const createApiKeyHandler: ExportedHandlerFetchHandler<Env> = async (
+  request: WorkerRequest<unknown, IncomingRequestCfProperties<unknown>>,
+  env: Env,
+  ctx: ExecutionContext
+): Promise<WorkerResponse> => {
+  const context = await createAuthenticatedContext(request, env, ctx);
+  const body = await parseJsonBody<CreateApiKeyRequest>(request);
+  validateCreateApiKeyRequest(body);
+  const result = await apiKeyProvider.createApiKey(context, body);
   return new workerGlobals.Response(JSON.stringify(result), {
     headers: { "Content-Type": "application/json" },
   });
+};
+
+const deleteApiKeyHandler: ExportedHandlerFetchHandler<Env> = async (
+  request: WorkerRequest<unknown, IncomingRequestCfProperties<unknown>>,
+  env: Env,
+  ctx: ExecutionContext
+): Promise<WorkerResponse> => {
+  const context = await createAuthenticatedContext(request, env, ctx);
+
+  const keyId = ctx.props?.urlParams?.id;
+  if (!keyId) {
+    throw new RuntError(ErrorType.InvalidRequest, {
+      message: "API key ID is required",
+    });
+  }
+  await apiKeyProvider.deleteApiKey(context, keyId);
+  return new workerGlobals.Response(null, { status: 204 });
+};
+
+const getApiKeyHandler: ExportedHandlerFetchHandler<Env> = async (
+  request: WorkerRequest<unknown, IncomingRequestCfProperties<unknown>>,
+  env: Env,
+  ctx: ExecutionContext
+): Promise<WorkerResponse> => {
+  const context = await createAuthenticatedContext(request, env, ctx);
+
+  const keyId = ctx.props?.urlParams?.id;
+  if (!keyId) {
+    throw new RuntError(ErrorType.InvalidRequest, {
+      message: "API key ID is required",
+    });
+  }
+
+  const result = await apiKeyProvider.getApiKey(context, keyId);
+  return new workerGlobals.Response(JSON.stringify(result), {
+    headers: { "Content-Type": "application/json" },
+  });
+};
+
+const listApiKeysHandler: ExportedHandlerFetchHandler<Env> = async (
+  request: WorkerRequest<unknown, IncomingRequestCfProperties<unknown>>,
+  env: Env,
+  ctx: ExecutionContext
+): Promise<WorkerResponse> => {
+  const context = await createAuthenticatedContext(request, env, ctx);
+  const url = new URL(request.url);
+  const limit = parseInt(url.searchParams.get("limit") || "100");
+  const offset = parseInt(url.searchParams.get("offset") || "0");
+
+  const result = await apiKeyProvider.listApiKeys(context, { limit, offset });
+  return new workerGlobals.Response(JSON.stringify(result), {
+    headers: { "Content-Type": "application/json" },
+  });
+};
+
+const revokeApiKeyHandler: ExportedHandlerFetchHandler<Env> = async (
+  request: WorkerRequest<unknown, IncomingRequestCfProperties<unknown>>,
+  env: Env,
+  ctx: ExecutionContext
+): Promise<WorkerResponse> => {
+  const context = await createAuthenticatedContext(request, env, ctx);
+
+  if (!apiKeyProvider.capabilities.has(ApiKeyCapabilities.Revoke)) {
+    throw new RuntError(ErrorType.CapabilityNotAvailable, {
+      message: "Revoke capability is not supported",
+    });
+  }
+
+  const body = await parseJsonBody<{ revoked: boolean }>(request);
+  validateRevokeApiKeyRequest(body);
+
+  const keyId = ctx.props?.urlParams?.id;
+  if (!keyId) {
+    throw new RuntError(ErrorType.InvalidRequest, {
+      message: "API key ID is required",
+    });
+  }
+  await apiKeyProvider.revokeApiKey(context, keyId);
+  return new workerGlobals.Response(null, { status: 204 });
+};
+
+const matchRoute = (
+  route: ReturnType<typeof pathToRegexp>,
+  pathname: string
+) => {
+  const match = route.regexp.exec(pathname);
+  if (!match) return null;
+
+  const params: Record<string, string> = {};
+  route.keys.forEach((key, index) => {
+    if (key.name) {
+      params[key.name] = match[index + 1];
+    }
+  });
+  return params;
 };
 
 const mainHandler: ExportedHandlerFetchHandler<Env> = async (
@@ -159,12 +281,44 @@ const mainHandler: ExportedHandlerFetchHandler<Env> = async (
   ctx: ExecutionContext
 ) => {
   try {
-    if (
-      request.method === "POST" &&
-      new URL(request.url).pathname === "/api/api-keys"
-    ) {
-      const response = await createApiKeyHandler(request, env, ctx);
-      return response;
+    const url = new URL(request.url);
+    const pathname = url.pathname;
+
+    if (request.method === "POST") {
+      const params = matchRoute(pathToRegexp("/api/api-keys"), pathname);
+      if (params) {
+        ctx.props = { urlParams: params };
+        const response = await createApiKeyHandler(request, env, ctx);
+        return response;
+      }
+    } else if (request.method === "DELETE") {
+      const params = matchRoute(pathToRegexp("/api/api-keys/:id"), pathname);
+      if (params) {
+        ctx.props = { urlParams: params };
+        const response = await deleteApiKeyHandler(request, env, ctx);
+        return response;
+      }
+    } else if (request.method === "GET") {
+      const params = matchRoute(pathToRegexp("/api/api-keys/:id"), pathname);
+      if (params) {
+        ctx.props = { urlParams: params };
+        const response = await getApiKeyHandler(request, env, ctx);
+        return response;
+      }
+
+      const listParams = matchRoute(pathToRegexp("/api/api-keys"), pathname);
+      if (listParams) {
+        ctx.props = { urlParams: listParams };
+        const response = await listApiKeysHandler(request, env, ctx);
+        return response;
+      }
+    } else if (request.method === "PATCH") {
+      const params = matchRoute(pathToRegexp("/api/api-keys/:id"), pathname);
+      if (params) {
+        ctx.props = { urlParams: params };
+        const response = await revokeApiKeyHandler(request, env, ctx);
+        return response;
+      }
     }
     throw new RuntError(ErrorType.NotFound, {
       message: "Unknown API endpoint",

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "lucide-react": "^0.514.0",
     "modern-normalize": "^3.0.1",
     "openid-client": "^6.6.2",
+    "path-to-regexp": "^8.2.0",
     "psl": "^1.15.0",
     "react": "19.0.0",
     "react-dom": "19.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -151,6 +151,9 @@ importers:
       openid-client:
         specifier: ^6.6.2
         version: 6.6.2
+      path-to-regexp:
+        specifier: ^8.2.0
+        version: 8.2.0
       psl:
         specifier: ^1.15.0
         version: 1.15.0


### PR DESCRIPTION
Implements:
 - GET /api/api-keys
 - GET /api/api-keys/:id
 - PATCH /api/api-keys/:id
 - DELETE /api/api-keys/:id

# Test plan
```sh
code=$(echo '{"firstName":"hello","lastName":"world","email":"test@example.com"}' | base64)

response=$(curl -s -X POST http://localhost:8787/local_oidc/token \
  -H "Content-Type: application/x-www-form-urlencoded" \
  -d "grant_type=authorization_code" \
  -d "client_id=local-anode-client" \
  -d "code=$code" \
  -d "redirect_uri=http://localhost:5173/auth/callback")

# Extract access_token from the JSON response
access_token=$(echo "$response" | jq -r '.access_token')

curl -X POST http://localhost:8787/api/api-keys \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer $access_token" \
  -d '{
    "scopes": ["runt:read", "runt:execute"],
    "expiresAt": "2024-12-31T23:59:59Z",
    "resources": [{"type": "notebook", "id": "123"}],
    "name": "Test API Key",
    "userGenerated": true
  }'

# List all API keys
echo "Listing all API keys..."
keys_response=$(curl -s http://localhost:8787/api/api-keys \
  -H "Authorization: Bearer $access_token")

echo "$keys_response" | jq '.'

# Extract the ID from the first entry and store it in a variable
first_key_id=$(echo "$keys_response" | jq -r '.[0].id')

echo "First key ID: $first_key_id"

# Get details for the specific key
echo "Getting details for key ID: $first_key_id"
key_details=$(curl -s http://localhost:8787/api/api-keys/$first_key_id \
  -H "Authorization: Bearer $access_token")

echo "$key_details" | jq '.'

# Revoke the key by setting revoked: true
echo "Revoking key ID: $first_key_id"
revoke_response=$(curl -s -X PATCH http://localhost:8787/api/api-keys/$first_key_id \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer $access_token" \
  -d '{"revoked": true}')

echo "Revoke response:"
echo "$revoke_response" | jq '.'
```

## Test response
```
Listing all API keys...
[
  {
    "id": "01989f0c-5218-7595-bf9e-eeab1680b86d",
    "userId": "83eaf1ce-85a4-5639-9307-59eb03e318b3",
    "revoked": true,
    "scopes": [
      "runt:read",
      "runt:execute"
    ],
    "expiresAt": "2024-12-31T23:59:59Z",
    "userGenerated": true,
    "name": "Test API Key"
  },
  {
    "id": "0198a003-322d-72ef-a60d-fc76b313f130",
    "userId": "83eaf1ce-85a4-5639-9307-59eb03e318b3",
    "revoked": false,
    "scopes": [
      "runt:read",
      "runt:execute"
    ],
    "expiresAt": "2024-12-31T23:59:59Z",
    "userGenerated": true,
    "name": "Test API Key",
    "resources": [
      {
        "type": "notebook",
        "id": "123"
      }
    ]
  }
]
First key ID: 01989f0c-5218-7595-bf9e-eeab1680b86d
Getting details for key ID: 01989f0c-5218-7595-bf9e-eeab1680b86d
{
  "id": "01989f0c-5218-7595-bf9e-eeab1680b86d",
  "userId": "83eaf1ce-85a4-5639-9307-59eb03e318b3",
  "revoked": true,
  "scopes": [
    "runt:read",
    "runt:execute"
  ],
  "expiresAt": "2024-12-31T23:59:59Z",
  "userGenerated": true,
  "name": "Test API Key"
}
```