### PR TITLE
Iframe refinements

### DIFF
--- a/iframe-outputs/src/components/IframeReactApp.tsx
+++ b/iframe-outputs/src/components/IframeReactApp.tsx
@@ -6,7 +6,7 @@ export const IframeReactApp: React.FC = () => {
   const { outputs } = useIframeCommsChild();
 
   if (outputs.length === 0) {
-    return "No content yet";
+    return null;
   }
 
   // Default content or non-React mode

--- a/iframe-outputs/src/style.css
+++ b/iframe-outputs/src/style.css
@@ -14,6 +14,7 @@ Docs: https://tailwindcss.com/docs/preflight#overview
 @import "tw-animate-css";
 @plugin "@tailwindcss/typography";
 @source "../../src/components/outputs/shared-with-iframe";
+@source "../../src/components/ui";
 
 :root {
   --dataframe-border: 1px solid #e5e7eb;

--- a/src/components/notebook/NotebookViewer.tsx
+++ b/src/components/notebook/NotebookViewer.tsx
@@ -319,6 +319,7 @@ export const NotebookViewer: React.FC<NotebookViewerProps> = ({
           </Suspense>
         )}
       </div>
+      <div className="h-[70vh]"></div>
       {/* Build info footer */}
       <div className="mt-8 flex justify-center border-t px-4 py-2 text-center">
         <GitCommitHash />

--- a/src/components/outputs/MaybeCellOutputs.tsx
+++ b/src/components/outputs/MaybeCellOutputs.tsx
@@ -10,7 +10,7 @@ export const MaybeCellOutputs = ({
   outputs,
   shouldUseIframe,
 }: {
-  outputs: OutputData[];
+  outputs: readonly OutputData[];
   shouldUseIframe: boolean;
 }) => {
   const outputDeltas = useQuery(
@@ -20,7 +20,7 @@ export const MaybeCellOutputs = ({
   // Apply grouping strategy based on cell type
   const processedOutputs = useMemo(() => {
     // TODO: doesn't .sort mutate?
-    const sorted = outputs.sort(
+    const sorted = [...outputs].sort(
       (a: OutputData, b: OutputData) => a.position - b.position
     );
     const grouped = groupConsecutiveStreamOutputs(sorted);

--- a/src/components/outputs/MaybeCellOutputs.tsx
+++ b/src/components/outputs/MaybeCellOutputs.tsx
@@ -1,17 +1,21 @@
 import { OutputData } from "@/schema";
 import { groupConsecutiveStreamOutputs } from "@/util/output-grouping";
 import { useQuery } from "@livestore/react";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { SingleOutput } from "./shared-with-iframe/SingleOutput";
 import { useIframeCommsParent } from "./shared-with-iframe/comms";
 import { outputsDeltasQuery, processDeltas } from "@/queries/outputDeltas";
+import { cn } from "@/lib/utils";
+import { useDebounce } from "react-use";
 
 export const MaybeCellOutputs = ({
   outputs,
   shouldUseIframe,
+  isLoading,
 }: {
   outputs: readonly OutputData[];
   shouldUseIframe: boolean;
+  isLoading: boolean;
 }) => {
   const outputDeltas = useQuery(
     outputsDeltasQuery(outputs.map((output) => output.id))
@@ -19,7 +23,6 @@ export const MaybeCellOutputs = ({
 
   // Apply grouping strategy based on cell type
   const processedOutputs = useMemo(() => {
-    // TODO: doesn't .sort mutate?
     const sorted = [...outputs].sort(
       (a: OutputData, b: OutputData) => a.position - b.position
     );
@@ -30,9 +33,18 @@ export const MaybeCellOutputs = ({
   if (!outputs.length) return null;
 
   return (
-    <div className="outputs-container px-4 py-2">
+    <div
+      className={cn(
+        "outputs-container px-4 py-2 transition-opacity duration-300",
+        isLoading && "opacity-50"
+      )}
+    >
       {shouldUseIframe ? (
-        <IframeOutput outputs={processedOutputs} isReact />
+        <IframeOutput
+          outputs={processedOutputs}
+          isReact
+          className="transition-[height] duration-300"
+        />
       ) : (
         processedOutputs.map((output: OutputData, index: number) => (
           <div
@@ -70,6 +82,15 @@ export const IframeOutput: React.FC<IframeOutputProps> = ({
     outputs,
   });
 
+  const [debouncedIframeHeight, setDebouncedIframeHeight] =
+    useState(iframeHeight);
+
+  // Iframe can get height updates pretty often, but we want to avoid layout jumping each time
+  // TODO: ensure that it's a leading debounce!
+  useDebounce(() => setDebouncedIframeHeight(iframeHeight), 200, [
+    iframeHeight,
+  ]);
+
   return (
     <iframe
       src={
@@ -78,7 +99,7 @@ export const IframeOutput: React.FC<IframeOutputProps> = ({
       ref={iframeRef}
       className={className}
       width="100%"
-      height={iframeHeight}
+      height={debouncedIframeHeight}
       style={style}
       sandbox="allow-scripts allow-same-origin"
     />

--- a/src/components/outputs/MaybeCellOutputs.tsx
+++ b/src/components/outputs/MaybeCellOutputs.tsx
@@ -23,10 +23,7 @@ export const MaybeCellOutputs = ({
 
   // Apply grouping strategy based on cell type
   const processedOutputs = useMemo(() => {
-    const sorted = [...outputs].sort(
-      (a: OutputData, b: OutputData) => a.position - b.position
-    );
-    const grouped = groupConsecutiveStreamOutputs(sorted);
+    const grouped = groupConsecutiveStreamOutputs(outputs);
     return processDeltas(grouped, outputDeltas);
   }, [outputs, outputDeltas]);
 
@@ -36,7 +33,7 @@ export const MaybeCellOutputs = ({
     <div
       className={cn(
         "outputs-container px-4 py-2 transition-opacity duration-300",
-        isLoading && "opacity-50"
+        isLoading ? "opacity-50" : "opacity-100"
       )}
     >
       {shouldUseIframe ? (

--- a/src/components/outputs/shared-with-iframe/SuspenseSpinner.tsx
+++ b/src/components/outputs/shared-with-iframe/SuspenseSpinner.tsx
@@ -1,8 +1,17 @@
 import { Suspense } from "react";
 import { Spinner } from "../../ui/Spinner";
 
+import React from "react";
+import { useTimeout } from "react-use";
+
+function DelayedSpinner({ delay = 500 }) {
+  const [isReady] = useTimeout(delay);
+
+  return isReady() ? <LoadingSpinner /> : null;
+}
+
 export function SuspenseSpinner({ children }: { children: React.ReactNode }) {
-  return <Suspense fallback={<LoadingSpinner />}>{children}</Suspense>;
+  return <Suspense fallback={<DelayedSpinner />}>{children}</Suspense>;
 }
 
 export const LoadingSpinner = () => (

--- a/src/hooks/useCellOutputs.tsx
+++ b/src/hooks/useCellOutputs.tsx
@@ -14,7 +14,9 @@ export const useCellOutputs = (cellId: string): CellOutputsResult => {
   const [staleOutputs, setStaleOutputs] = useState<OutputData[]>([]);
 
   const outputs = useQuery(
-    queryDb(tables.outputs.select().where({ cellId }))
+    queryDb(
+      tables.outputs.select().where({ cellId }).orderBy("position", "asc")
+    )
   ) as OutputData[];
 
   const hasOutputs = outputs.length > 0;

--- a/src/hooks/useCellOutputs.tsx
+++ b/src/hooks/useCellOutputs.tsx
@@ -1,13 +1,18 @@
 import { OutputData, tables } from "@/schema";
 import { queryDb } from "@livestore/livestore";
 import { useQuery } from "@livestore/react";
+import { useState } from "react";
 
 interface CellOutputsResult {
   outputs: OutputData[];
   hasOutputs: boolean;
+  staleOutputs: OutputData[];
+  setStaleOutputs: (outputs: OutputData[]) => void;
 }
 
 export const useCellOutputs = (cellId: string): CellOutputsResult => {
+  const [staleOutputs, setStaleOutputs] = useState<OutputData[]>([]);
+
   const outputs = useQuery(
     queryDb(tables.outputs.select().where({ cellId }))
   ) as OutputData[];
@@ -17,5 +22,7 @@ export const useCellOutputs = (cellId: string): CellOutputsResult => {
   return {
     outputs,
     hasOutputs,
+    staleOutputs,
+    setStaleOutputs,
   };
 };

--- a/src/util/output-grouping.ts
+++ b/src/util/output-grouping.ts
@@ -16,7 +16,7 @@ function isMarkdownOutput(output: OutputData): boolean {
 }
 
 export function groupConsecutiveStreamOutputs(
-  outputs: OutputData[]
+  outputs: readonly OutputData[]
 ): OutputData[] {
   const result: OutputData[] = [];
 


### PR DESCRIPTION
- Clean up height thrashing in cell input footer (from chevron)
- Show stale output in gray until new outputs are recieved
- Don't send iframe height as often
- Animate output height, and debounce it to limit layout shifts when multiple outputs
- Add half-page spacer below all cells
	1. Helps with items added to the end causing the page to expand up when scrolled all the wy down
	2. Lets you scroll the last your cell to any position on the page
- Delay output spinner to avoid jank
- Don't accidentally mutate outputs
- Clean up iframe states better:
	- Clean up height thrashing in cell input footer (from chevron)
	- Show stale output in gray until new outputs are recieved
	- Don't send iframe height as often
	- Animate output height, and debounce it to limit layout shifts when multiple outputs

Iframe loading improvements:

https://github.com/user-attachments/assets/6fa964c2-b857-40eb-9880-4bd00452940e

Height debouncing:

https://github.com/user-attachments/assets/81c45b9a-e48c-49a9-92f1-7cdd5093d501

Show stale outputs (artificially slow runtime):

https://github.com/user-attachments/assets/5d3dffee-d471-4aa2-ad82-03908dc24282

Show stale outputs prevents page from being reloaded:

https://github.com/user-attachments/assets/e619e566-a7f8-4767-b4ff-ffc516fb4b08