### PR TITLE
Add /api/me endpoint for user identity discovery

### DIFF
--- a/backend/routes.ts
+++ b/backend/routes.ts
@@ -40,6 +40,22 @@ api.get("/health", (c) => {
   });
 });
 
+// Me endpoint - returns authenticated user info
+api.get("/me", authMiddleware, (c) => {
+  const passport = c.get("passport");
+  if (!passport) {
+    return c.json({ error: "Authentication failed" }, 401);
+  }
+  return c.json({
+    id: passport.user.id,
+    email: passport.user.email,
+    name: passport.user.name,
+    givenName: passport.user.givenName,
+    familyName: passport.user.familyName,
+    isAnonymous: passport.user.isAnonymous,
+  });
+});
+
 // Debug auth endpoint - no auth middleware, handles auth internally
 api.post("/debug/auth", async (c) => {
   console.log("🔧 Debug auth endpoint called");


### PR DESCRIPTION
**Adds `/api/me` endpoint** that works with any authentication method.

**Purpose:**
- Enable runtime agents and TUI to discover their authenticated user ID
- Provide fail-fast authentication validation before WebSocket connection
- Universal whoami endpoint for all auth types (JWT, API key, service token)

**Returns:**
```json
{
  "id": "user-id",
  "email": "user@example.com", 
  "name": "User Name",
  "givenName": "User",
  "familyName": "Name",
  "isAnonymous": false
}
```

**Next Steps:**
- Update runtime agents to call `/api/me` before LiveStore connection
- Use returned `id` as `clientId` for consistent identity model
- Eliminates special-case clientId validation logic

**Testing:**
- Deployed to preview: `https://preview.runt.run/api/me`
- Works with existing authMiddleware (API key + JWT support)