### PR TITLE
enable console global in eslint for vite config

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -250,6 +250,7 @@ export default [
         module: "readonly",
         require: "readonly",
         exports: "readonly",
+        console: "readonly",
       },
     },
     rules: {


### PR DESCRIPTION
Makes eslint stop complaining about a console.error we have in the vite config (if getting the local git hash fails).