### PR TITLE
runbook sharing with email-first UX

### DIFF
--- a/backend/graphql/resolvers.ts
+++ b/backend/graphql/resolvers.ts
@@ -5,6 +5,7 @@ import type { PermissionsProvider } from "../permissions/types.ts";
 import {
   getUserById,
   getUsersByIds,
+  getUserByEmail,
   toGraphQLPublicUser,
   createFallbackUser,
 } from "../users/utils.ts";
@@ -190,6 +191,30 @@ export const resolvers = {
         throw new GraphQLError("Authentication required");
       }
       return context.user;
+    },
+
+    async userByEmail(
+      _parent: unknown,
+      args: { email: string },
+      context: GraphQLContext
+    ) {
+      const { user, DB } = context;
+      const { email } = args;
+
+      if (!user) {
+        throw new GraphQLError("Authentication required");
+      }
+
+      try {
+        const userRecord = await getUserByEmail(DB, email);
+        if (userRecord) {
+          return toGraphQLPublicUser(userRecord);
+        }
+        return null;
+      } catch (error) {
+        console.error("Failed to fetch user by email:", error);
+        return null;
+      }
     },
   },
 

--- a/backend/graphql/schema.ts
+++ b/backend/graphql/schema.ts
@@ -180,6 +180,11 @@ export const typeDefs = /* GraphQL */ `
     Get the current authenticated user (includes private data like email)
     """
     me: PrivateUser!
+
+    """
+    Look up a user by their email address (returns public profile only)
+    """
+    userByEmail(email: String!): User
   }
 
   type Mutation {

--- a/backend/users/utils.ts
+++ b/backend/users/utils.ts
@@ -58,6 +58,42 @@ export async function getUserById(
 }
 
 /**
+ * Get public user data by email (excludes private data for privacy)
+ * Returns null if user not found
+ */
+export async function getUserByEmail(
+  db: D1Database,
+  email: string
+): Promise<PublicUserData | null> {
+  try {
+    const user = await db
+      .prepare("SELECT id, given_name, family_name FROM users WHERE email = ?")
+      .bind(email)
+      .first<{
+        id: string;
+        given_name: string | null;
+        family_name: string | null;
+      }>();
+
+    if (!user) {
+      return null;
+    }
+
+    return {
+      id: user.id,
+      givenName: user.given_name,
+      familyName: user.family_name,
+    };
+  } catch (error) {
+    console.error("Failed to get user by email:", {
+      email,
+      error: error instanceof Error ? error.message : "Unknown error",
+    });
+    return null;
+  }
+}
+
+/**
  * Get multiple users by IDs (public data only)
  * Returns map of userId -> PublicUserData
  */

--- a/src/components/runbooks/RunbookCard.tsx
+++ b/src/components/runbooks/RunbookCard.tsx
@@ -1,16 +1,29 @@
-import React from "react";
+import React, { useState } from "react";
 import { Link } from "react-router-dom";
-import { Users, Clock, User } from "lucide-react";
+import { Users, Clock, User, Share2, MoreHorizontal } from "lucide-react";
 import { getRunbookVanityUrl } from "../../util/url-utils";
 import { Card, CardHeader, CardTitle, CardContent } from "../ui/card";
 import { Badge } from "../ui/badge";
+import { Button } from "../ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "../ui/dropdown-menu";
+import { SharingModal } from "./SharingModal";
 import type { Runbook } from "../../queries/runbooks";
 
 interface RunbookCardProps {
   runbook: Runbook;
+  onUpdate?: () => void;
 }
 
-export const RunbookCard: React.FC<RunbookCardProps> = ({ runbook }) => {
+export const RunbookCard: React.FC<RunbookCardProps> = ({
+  runbook,
+  onUpdate,
+}) => {
+  const [isSharingModalOpen, setIsSharingModalOpen] = useState(false);
   const formatDate = (dateString: string) => {
     return new Intl.DateTimeFormat("en-US", {
       month: "short",
@@ -31,59 +44,102 @@ export const RunbookCard: React.FC<RunbookCardProps> = ({ runbook }) => {
     }
   };
 
+  const canEdit = runbook.myPermission === "OWNER";
+
+  const handleShare = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsSharingModalOpen(true);
+  };
+
   return (
-    <Link
-      to={getRunbookVanityUrl(runbook.ulid, runbook.title)}
-      className="block transition-transform hover:scale-[1.02]"
-    >
-      <Card className="h-full transition-shadow hover:shadow-lg">
-        <CardHeader className="pb-3">
-          <div className="flex items-start justify-between gap-2">
-            <CardTitle className="line-clamp-2 min-h-[2.5rem] text-lg">
-              {runbook.title || "Untitled Runbook"}
-            </CardTitle>
-            <Badge
-              variant={getPermissionBadgeVariant(runbook.myPermission)}
-              className="shrink-0"
-            >
-              {runbook.myPermission.toLowerCase()}
-            </Badge>
-          </div>
-        </CardHeader>
-
-        <CardContent className="pt-0">
-          <div className="space-y-3 text-sm text-gray-600">
-            {/* Owner */}
-            <div className="flex items-center gap-2">
-              <User className="h-4 w-4 shrink-0" />
-              <span className="truncate">
-                {runbook.owner.givenName && runbook.owner.familyName
-                  ? `${runbook.owner.givenName} ${runbook.owner.familyName}`
-                  : "Unknown Owner"}
-              </span>
+    <>
+      <Link
+        to={getRunbookVanityUrl(runbook.ulid, runbook.title)}
+        className="block transition-transform hover:scale-[1.02]"
+      >
+        <Card className="h-full transition-shadow hover:shadow-lg">
+          <CardHeader className="pb-3">
+            <div className="flex items-start justify-between gap-2">
+              <CardTitle className="line-clamp-2 min-h-[2.5rem] text-lg">
+                {runbook.title || "Untitled Runbook"}
+              </CardTitle>
+              <div className="flex shrink-0 items-center gap-1">
+                <Badge
+                  variant={getPermissionBadgeVariant(runbook.myPermission)}
+                  className="shrink-0"
+                >
+                  {runbook.myPermission.toLowerCase()}
+                </Badge>
+                {canEdit && (
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="h-8 w-8 p-0"
+                        onClick={(e) => {
+                          e.preventDefault();
+                          e.stopPropagation();
+                        }}
+                      >
+                        <MoreHorizontal className="h-4 w-4" />
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end">
+                      <DropdownMenuItem onClick={handleShare}>
+                        <Share2 className="mr-2 h-4 w-4" />
+                        Share
+                      </DropdownMenuItem>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                )}
+              </div>
             </div>
+          </CardHeader>
 
-            {/* Collaborators count */}
-            {runbook.collaborators.length > 0 && (
+          <CardContent className="pt-0">
+            <div className="space-y-3 text-sm text-gray-600">
+              {/* Owner */}
               <div className="flex items-center gap-2">
-                <Users className="h-4 w-4 shrink-0" />
-                <span>
-                  {runbook.collaborators.length}{" "}
-                  {runbook.collaborators.length === 1
-                    ? "collaborator"
-                    : "collaborators"}
+                <User className="h-4 w-4 shrink-0" />
+                <span className="truncate">
+                  {runbook.owner.givenName && runbook.owner.familyName
+                    ? `${runbook.owner.givenName} ${runbook.owner.familyName}`
+                    : "Unknown Owner"}
                 </span>
               </div>
-            )}
 
-            {/* Last updated */}
-            <div className="flex items-center gap-2">
-              <Clock className="h-4 w-4 shrink-0" />
-              <span>Updated {formatDate(runbook.updatedAt)}</span>
+              {/* Collaborators count */}
+              {runbook.collaborators.length > 0 && (
+                <div className="flex items-center gap-2">
+                  <Users className="h-4 w-4 shrink-0" />
+                  <span>
+                    {runbook.collaborators.length}{" "}
+                    {runbook.collaborators.length === 1
+                      ? "collaborator"
+                      : "collaborators"}
+                  </span>
+                </div>
+              )}
+
+              {/* Last updated */}
+              <div className="flex items-center gap-2">
+                <Clock className="h-4 w-4 shrink-0" />
+                <span>Updated {formatDate(runbook.updatedAt)}</span>
+              </div>
             </div>
-          </div>
-        </CardContent>
-      </Card>
-    </Link>
+          </CardContent>
+        </Card>
+      </Link>
+
+      {/* Sharing Modal */}
+      <SharingModal
+        runbook={runbook}
+        isOpen={isSharingModalOpen}
+        onClose={() => setIsSharingModalOpen(false)}
+        onUpdate={() => onUpdate?.()}
+      />
+    </>
   );
 };

--- a/src/components/runbooks/RunbookViewer.tsx
+++ b/src/components/runbooks/RunbookViewer.tsx
@@ -1,6 +1,15 @@
 import React, { useState, useEffect } from "react";
 import { useParams, Link, useLocation, useNavigate } from "react-router-dom";
-import { ArrowLeft, Users, Clock, User, Edit2, Check, X } from "lucide-react";
+import {
+  ArrowLeft,
+  Users,
+  Clock,
+  User,
+  Edit2,
+  Check,
+  X,
+  Share2,
+} from "lucide-react";
 import { getRunbookVanityUrl, hasCorrectVanityUrl } from "../../util/url-utils";
 import { useQuery, useMutation } from "../../lib/graphql-client";
 import {
@@ -13,6 +22,7 @@ import { Button } from "../ui/button";
 import { Input } from "../ui/input";
 import { Badge } from "../ui/badge";
 import { LoadingState } from "../loading/LoadingState";
+import { SharingModal } from "./SharingModal";
 
 export const RunbookViewer: React.FC = () => {
   const { ulid } = useParams<{ ulid: string }>();
@@ -20,6 +30,7 @@ export const RunbookViewer: React.FC = () => {
   const navigate = useNavigate();
   const [isEditingTitle, setIsEditingTitle] = useState(false);
   const [editTitle, setEditTitle] = useState("");
+  const [isSharingModalOpen, setIsSharingModalOpen] = useState(false);
 
   // Get initial runbook data from router state (if navigated from creation)
   const initialRunbook = location.state?.initialRunbook as Runbook | undefined;
@@ -206,10 +217,24 @@ export const RunbookViewer: React.FC = () => {
               </div>
             </div>
 
-            {/* Permission badge */}
-            <Badge variant={getPermissionBadgeVariant(runbook.myPermission)}>
-              {runbook.myPermission.toLowerCase()}
-            </Badge>
+            <div className="flex items-center gap-2">
+              {/* Share button */}
+              {canEdit && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setIsSharingModalOpen(true)}
+                >
+                  <Share2 className="mr-2 h-4 w-4" />
+                  Share
+                </Button>
+              )}
+
+              {/* Permission badge */}
+              <Badge variant={getPermissionBadgeVariant(runbook.myPermission)}>
+                {runbook.myPermission.toLowerCase()}
+              </Badge>
+            </div>
           </div>
 
           {/* Metadata */}
@@ -269,6 +294,14 @@ export const RunbookViewer: React.FC = () => {
           </p>
         </div>
       </div>
+
+      {/* Sharing Modal */}
+      <SharingModal
+        runbook={runbook}
+        isOpen={isSharingModalOpen}
+        onClose={() => setIsSharingModalOpen(false)}
+        onUpdate={() => refetch()}
+      />
     </div>
   );
 };

--- a/src/components/runbooks/SharingModal.tsx
+++ b/src/components/runbooks/SharingModal.tsx
@@ -1,0 +1,281 @@
+import React, { useState, useMemo } from "react";
+import { Plus, Trash2, Mail, User, AlertCircle } from "lucide-react";
+import { useQuery, useMutation } from "../../lib/graphql-client";
+import {
+  USER_BY_EMAIL,
+  SHARE_RUNBOOK,
+  UNSHARE_RUNBOOK,
+  type Runbook,
+  type User as RunbookUser,
+} from "../../queries/runbooks";
+import { Button } from "../ui/button";
+import { Input } from "../ui/input";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "../ui/dialog";
+import { Badge } from "../ui/badge";
+
+interface SharingModalProps {
+  runbook: Runbook;
+  isOpen: boolean;
+  onClose: () => void;
+  onUpdate: () => void; // Callback to refresh runbook data
+}
+
+export const SharingModal: React.FC<SharingModalProps> = ({
+  runbook,
+  isOpen,
+  onClose,
+  onUpdate,
+}) => {
+  const [email, setEmail] = useState("");
+  const [isSharing, setIsSharing] = useState(false);
+
+  // Only lookup user if email looks valid and not empty
+  const shouldLookupUser = email.includes("@") && email.includes(".");
+
+  const [{ data: userLookupData, fetching: lookingUpUser }] = useQuery({
+    query: USER_BY_EMAIL,
+    variables: { email: email.trim() },
+    pause: !shouldLookupUser,
+  });
+
+  const [, shareRunbook] = useMutation(SHARE_RUNBOOK);
+  const [, unshareRunbook] = useMutation(UNSHARE_RUNBOOK);
+
+  const foundUser = userLookupData?.userByEmail;
+  const isUserAlreadyCollaborator = useMemo(() => {
+    if (!foundUser) return false;
+    return runbook.collaborators.some((c) => c.id === foundUser.id);
+  }, [foundUser, runbook.collaborators]);
+
+  const isOwnerTryingToShareWithSelf = useMemo(() => {
+    if (!foundUser) return false;
+    return foundUser.id === runbook.owner.id;
+  }, [foundUser, runbook.owner.id]);
+
+  const canShare = runbook.myPermission === "OWNER";
+
+  const handleShare = async () => {
+    if (
+      !foundUser ||
+      isSharing ||
+      isUserAlreadyCollaborator ||
+      isOwnerTryingToShareWithSelf
+    ) {
+      return;
+    }
+
+    setIsSharing(true);
+    try {
+      const result = await shareRunbook({
+        input: {
+          runbookUlid: runbook.ulid,
+          userId: foundUser.id,
+        },
+      });
+
+      if (result.error) {
+        console.error("Failed to share runbook:", result.error);
+        // TODO: Show error toast
+      } else {
+        setEmail("");
+        onUpdate(); // Refresh the runbook data
+      }
+    } catch (err) {
+      console.error("Failed to share runbook:", err);
+      // TODO: Show error toast
+    } finally {
+      setIsSharing(false);
+    }
+  };
+
+  const handleUnshare = async (userId: string) => {
+    try {
+      const result = await unshareRunbook({
+        input: {
+          runbookUlid: runbook.ulid,
+          userId,
+        },
+      });
+
+      if (result.error) {
+        console.error("Failed to unshare runbook:", result.error);
+        // TODO: Show error toast
+      } else {
+        onUpdate(); // Refresh the runbook data
+      }
+    } catch (err) {
+      console.error("Failed to unshare runbook:", err);
+      // TODO: Show error toast
+    }
+  };
+
+  const formatUserName = (user: RunbookUser) => {
+    if (user.givenName && user.familyName) {
+      return `${user.givenName} ${user.familyName}`;
+    }
+    return user.givenName || user.familyName || "Unknown User";
+  };
+
+  const handleClose = () => {
+    setEmail("");
+    onClose();
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={handleClose}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>Share Runbook</DialogTitle>
+          <DialogDescription>
+            Collaborate on "{runbook.title || "Untitled Runbook"}" with others
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-6">
+          {/* Add Collaborator */}
+          {canShare && (
+            <div className="space-y-3">
+              <div className="flex items-center gap-2">
+                <Mail className="h-4 w-4 text-gray-500" />
+                <label className="text-sm font-medium">Add collaborator</label>
+              </div>
+
+              <div className="space-y-2">
+                <Input
+                  type="email"
+                  placeholder="Enter email address..."
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  className="w-full"
+                />
+
+                {/* User lookup results */}
+                {shouldLookupUser && (
+                  <div className="rounded border bg-gray-50 p-3">
+                    {lookingUpUser ? (
+                      <div className="flex items-center gap-2 text-sm text-gray-600">
+                        <div className="h-4 w-4 animate-spin rounded-full border-2 border-gray-300 border-t-gray-600" />
+                        Looking up user...
+                      </div>
+                    ) : foundUser ? (
+                      <div className="space-y-2">
+                        <div className="flex items-center gap-2">
+                          <User className="h-4 w-4 text-green-600" />
+                          <span className="font-medium text-green-700">
+                            {formatUserName(foundUser)}
+                          </span>
+                        </div>
+
+                        {isOwnerTryingToShareWithSelf ? (
+                          <div className="flex items-start gap-2 text-sm text-amber-600">
+                            <AlertCircle className="mt-0.5 h-3 w-3 shrink-0" />
+                            <span>
+                              You are already the owner of this runbook
+                            </span>
+                          </div>
+                        ) : isUserAlreadyCollaborator ? (
+                          <div className="flex items-start gap-2 text-sm text-amber-600">
+                            <AlertCircle className="mt-0.5 h-3 w-3 shrink-0" />
+                            <span>This user is already a collaborator</span>
+                          </div>
+                        ) : (
+                          <Button
+                            size="sm"
+                            onClick={handleShare}
+                            disabled={isSharing}
+                            className="w-full"
+                          >
+                            <Plus className="mr-1 h-3 w-3" />
+                            {isSharing ? "Adding..." : "Add as collaborator"}
+                          </Button>
+                        )}
+                      </div>
+                    ) : (
+                      <div className="flex items-start gap-2 text-sm text-gray-600">
+                        <AlertCircle className="mt-0.5 h-3 w-3 shrink-0" />
+                        <div>
+                          <div>No user found with this email address.</div>
+                          <div className="mt-1 text-xs text-gray-500">
+                            They'll need to sign up for Runt first.
+                          </div>
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
+
+          {/* Current Access */}
+          <div className="space-y-3">
+            <div className="flex items-center gap-2">
+              <User className="h-4 w-4 text-gray-500" />
+              <label className="text-sm font-medium">Current access</label>
+            </div>
+
+            <div className="space-y-2">
+              {/* Owner */}
+              <div className="flex items-center justify-between rounded border bg-blue-50 p-3">
+                <div>
+                  <div className="font-medium">
+                    {formatUserName(runbook.owner)}
+                  </div>
+                  <div className="text-xs text-gray-600">Owner</div>
+                </div>
+                <Badge variant="default">Owner</Badge>
+              </div>
+
+              {/* Collaborators */}
+              {runbook.collaborators.map((collaborator) => (
+                <div
+                  key={collaborator.id}
+                  className="flex items-center justify-between rounded border bg-gray-50 p-3"
+                >
+                  <div>
+                    <div className="font-medium">
+                      {formatUserName(collaborator)}
+                    </div>
+                    <div className="text-xs text-gray-600">Can edit</div>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <Badge variant="secondary">Writer</Badge>
+                    {canShare && (
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => handleUnshare(collaborator.id)}
+                        className="text-red-600 hover:text-red-700"
+                      >
+                        <Trash2 className="h-3 w-3" />
+                      </Button>
+                    )}
+                  </div>
+                </div>
+              ))}
+
+              {runbook.collaborators.length === 0 && (
+                <div className="rounded border-2 border-dashed border-gray-200 p-6 text-center">
+                  <div className="text-sm text-gray-500">
+                    No collaborators yet
+                  </div>
+                  {!canShare && (
+                    <div className="mt-1 text-xs text-gray-400">
+                      Only the owner can add collaborators
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/src/components/runbooks/SimpleUserProfile.tsx
+++ b/src/components/runbooks/SimpleUserProfile.tsx
@@ -1,0 +1,125 @@
+import React, { useState } from "react";
+import { LogOut, Settings } from "lucide-react";
+import { useAuth } from "../auth/AuthProvider.js";
+import { Button } from "../ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "../ui/dropdown-menu";
+import { Avatar } from "../ui/Avatar.js";
+
+interface SimpleUserProfileProps {
+  className?: string;
+}
+
+export const SimpleUserProfile: React.FC<SimpleUserProfileProps> = ({
+  className = "",
+}) => {
+  const { signOut, user } = useAuth();
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+
+  const getDisplayName = (user: any) => {
+    if (!user) return "Unknown User";
+
+    const { givenName, familyName, email } = user;
+
+    if (givenName && familyName) {
+      return `${givenName} ${familyName}`;
+    }
+
+    if (givenName) return givenName;
+    if (familyName) return familyName;
+
+    // Fall back to email if no name parts
+    if (email) {
+      const localPart = email.split("@")[0];
+      return localPart;
+    }
+
+    return "Unknown User";
+  };
+
+  const getUserInitials = (user: any) => {
+    if (!user) return "?";
+
+    const { givenName, familyName, email } = user;
+
+    if (givenName && familyName) {
+      return `${givenName[0]}${familyName[0]}`.toUpperCase();
+    }
+
+    if (givenName) return givenName[0].toUpperCase();
+    if (familyName) return familyName[0].toUpperCase();
+
+    // Fall back to email if no name parts
+    if (email) {
+      return email[0].toUpperCase();
+    }
+
+    return "?";
+  };
+
+  const handleSignOut = async () => {
+    try {
+      await signOut();
+    } catch (error) {
+      console.error("Failed to sign out:", error);
+    }
+  };
+
+  const displayName = getDisplayName(user);
+  const initials = getUserInitials(user);
+
+  return (
+    <div className={className}>
+      <DropdownMenu open={isDropdownOpen} onOpenChange={setIsDropdownOpen}>
+        <DropdownMenuTrigger asChild>
+          <Button variant="ghost" className="h-8 w-8 rounded-full p-0">
+            <Avatar initials={initials} size="md" />
+          </Button>
+        </DropdownMenuTrigger>
+
+        <DropdownMenuContent align="end" className="w-56">
+          {/* User Info */}
+          <div className="px-2 py-1.5">
+            <div className="flex items-center gap-2">
+              <Avatar initials={initials} size="md" />
+              <div className="flex flex-col space-y-1">
+                <p className="text-sm leading-none font-medium">
+                  {displayName}
+                </p>
+                {user?.email && (
+                  <p className="text-muted-foreground text-xs leading-none">
+                    {user.email}
+                  </p>
+                )}
+              </div>
+            </div>
+          </div>
+
+          <DropdownMenuSeparator />
+
+          {/* Actions */}
+          <DropdownMenuItem disabled className="cursor-not-allowed">
+            <Settings className="mr-2 h-4 w-4" />
+            Settings
+            <span className="text-muted-foreground ml-auto text-xs">Soon</span>
+          </DropdownMenuItem>
+
+          <DropdownMenuSeparator />
+
+          <DropdownMenuItem
+            onClick={handleSignOut}
+            className="text-red-600 focus:text-red-600"
+          >
+            <LogOut className="mr-2 h-4 w-4" />
+            Sign out
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+};

--- a/src/queries/runbooks.ts
+++ b/src/queries/runbooks.ts
@@ -58,6 +58,17 @@ export const GET_ME = gql`
   }
 `;
 
+// Query to look up a user by email
+export const USER_BY_EMAIL = gql`
+  query UserByEmail($email: String!) {
+    userByEmail(email: $email) {
+      id
+      givenName
+      familyName
+    }
+  }
+`;
+
 // Mutation to create a new runbook
 export const CREATE_RUNBOOK = gql`
   ${RUNBOOK_FRAGMENT}


### PR DESCRIPTION
- Add userByEmail GraphQL query and resolver for user lookup
- Create SharingModal
- Add share buttons to runbook cards and viewer
- Implement permission management with visual hierarchy
- Fix dashboard UI issues:
  - Hide empty 'My Runbooks' filter
  - Add smart default filter selection
  - Add SimpleUserProfile without LiveStore dependencies
- Maintain privacy with no email enumeration
- Show user confirmation when email found in system
- Handle graceful messaging when user doesn't exist yet