### PR TITLE
keep a stable sync payload for the livestore provider

### DIFF
--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -213,6 +213,15 @@ const LiveStoreApp: React.FC<{
     accessToken,
   } = useAuth();
 
+  const syncPayloadRef = useRef<{ authToken: string; clientId: string }>({
+    authToken: accessToken,
+    clientId,
+  });
+
+  useEffect(() => {
+    syncPayloadRef.current.authToken = accessToken;
+  }, [accessToken]);
+
   const adapter = makePersistedAdapter({
     storage: { type: "opfs" },
     worker: LiveStoreWorker,
@@ -232,7 +241,7 @@ const LiveStoreApp: React.FC<{
       }}
       batchUpdates={batchUpdates}
       storeId={storeId}
-      syncPayload={{ authToken: accessToken, clientId }}
+      syncPayload={syncPayloadRef.current}
     >
       <LiveStoreReadyDetector onReady={onLiveStoreReady} />
       <NotebookApp />


### PR DESCRIPTION
## Problem

I've finally realized why the app is scrolling up on token refresh... when the auth updates the authToken we have a fresh sync payload to LiveStore and will re-render the whole notebook (and re-establish the websocket).

## Solution

Stop making a new object every time the access token changes, so that LiveStore doesn't re-render the whole app yet can use a new access token if the websocket drops.