### PR TITLE
Fix LiveStore CLIENT_ID_MISMATCH error

### DIFF
--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -227,7 +227,8 @@ const LiveStoreApp: React.FC<{
 
   useEffect(() => {
     syncPayloadRef.current.authToken = accessToken;
-  }, [accessToken]);
+    syncPayloadRef.current.clientId = clientId;
+  }, [accessToken, clientId]);
 
   const adapter = makePersistedAdapter({
     storage: { type: "opfs" },


### PR DESCRIPTION
Update syncPayloadRef to include clientId in useEffect dependency array. The syncPayload was being initialized with the correct clientId but the useEffect was only updating authToken, possibly leaving clientId as an empty string on subsequent auth state changes.