### PR TITLE
Update preview deployment workflow

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,12 +1,12 @@
-name: Deploy Iframe Outputs (Preview)
+name: Deploy Preview (Base App + Iframe Outputs)
 
 on:
   pull_request:
     branches: [main]
 
 jobs:
-  deploy-iframe-outputs:
-    name: Build and Deploy Iframe Outputs (Preview)
+  deploy-preview:
+    name: Build and Deploy Preview
     runs-on: ubuntu-latest
     environment:
       name: preview
@@ -41,23 +41,43 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pnpm-store-
 
-      - name: Install dependencies (root)
+      - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build iframe assets
+      - name: Build base app (preview mode)
+        run: pnpm build --mode preview
+        env:
+          VITE_AUTH_CLIENT_ID: ${{ vars.VITE_AUTH_CLIENT_ID }}
+          VITE_AUTH_REDIRECT_URI: ${{ vars.VITE_AUTH_REDIRECT_URI }}
+          VITE_AUTH_URI: ${{ vars.VITE_AUTH_URI }}
+          VITE_IFRAME_OUTPUT_URI: ${{ vars.VITE_IFRAME_OUTPUT_URI }}
+          VITE_LIVESTORE_SYNC_URL: ${{ vars.VITE_LIVESTORE_SYNC_URL }}
+          VITE_RUNTIME_COMMAND: ${{ vars.VITE_RUNTIME_COMMAND }}
+          VITE_GIT_COMMIT_HASH: ${{ github.sha }}
+
+      - name: Build iframe outputs
         run: pnpm run build:iframe
 
-      - name: Install worker dependencies
+      - name: Install iframe worker dependencies
         working-directory: iframe-outputs/worker
         run: pnpm install --frozen-lockfile
 
-      - name: Deploy worker to Preview
+      - name: Deploy base app to Preview
+        run: pnpm deploy:preview
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+      - name: Deploy iframe worker to Preview
         working-directory: iframe-outputs/worker
         run: pnpm run deploy:preview
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
-      - name: Deploy worker to Production (dry-run)
+      - name: Deploy base app to Production (dry-run)
+        run: pnpm deploy:production-dry-run
+
+      - name: Deploy iframe worker to Production (dry-run)
         working-directory: iframe-outputs/worker
         run: pnpm run deploy:production-dry-run

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -12,7 +12,7 @@ jobs:
       name: preview
     concurrency:
       group: preview-deploy-${{ github.ref }}
-      cancel-in-progress: true
+      cancel-in-progress: false
 
     steps:
       - name: Checkout code
@@ -62,22 +62,28 @@ jobs:
         working-directory: iframe-outputs/worker
         run: pnpm install --frozen-lockfile
 
+      - name: Apply database migrations (Preview)
+        run: pnpm wrangler d1 migrations apply DB --env preview --remote --verbose
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
       - name: Deploy base app to Preview
-        run: pnpm deploy:preview
+        run: pnpm wrangler deploy --env preview --verbose
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
       - name: Deploy iframe worker to Preview
         working-directory: iframe-outputs/worker
-        run: pnpm run deploy:preview
+        run: pnpm run deploy:preview --verbose
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
       - name: Deploy base app to Production (dry-run)
-        run: pnpm deploy:production-dry-run
+        run: pnpm wrangler deploy --env production --dry-run --verbose
 
       - name: Deploy iframe worker to Production (dry-run)
         working-directory: iframe-outputs/worker
-        run: pnpm run deploy:production-dry-run
+        run: pnpm run deploy:production-dry-run --verbose

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -12,7 +12,7 @@ jobs:
       name: preview
     concurrency:
       group: preview-deploy-${{ github.ref }}
-      cancel-in-progress: false
+      cancel-in-progress: true
 
     steps:
       - name: Checkout code
@@ -63,27 +63,27 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Apply database migrations (Preview)
-        run: pnpm wrangler d1 migrations apply DB --env preview --remote --verbose
+        run: pnpm wrangler d1 migrations apply DB --env preview --remote
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
       - name: Deploy base app to Preview
-        run: pnpm wrangler deploy --env preview --verbose
+        run: pnpm wrangler deploy --env preview
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
       - name: Deploy iframe worker to Preview
         working-directory: iframe-outputs/worker
-        run: pnpm run deploy:preview --verbose
+        run: pnpm run deploy:preview
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
       - name: Deploy base app to Production (dry-run)
-        run: pnpm wrangler deploy --env production --dry-run --verbose
+        run: pnpm wrangler deploy --env production --dry-run
 
       - name: Deploy iframe worker to Production (dry-run)
         working-directory: iframe-outputs/worker
-        run: pnpm run deploy:production-dry-run --verbose
+        run: pnpm run deploy:production-dry-run


### PR DESCRIPTION
- Rename deploy-iframe-outputs.yml to deploy-preview.yml
- Deploy both base app and iframe outputs to preview
- Add all required VITE env vars for base app build
- Use GitHub context for commit hash
- Remove unnecessary env vars from iframe build (doesn't use any)