### PR TITLE
Loading improvements

### DIFF
--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -46,6 +46,7 @@ const AuthorizePage = React.lazy(
 import {
   AuthProvider,
   useAuthenticatedUser,
+  useAuth,
 } from "./components/auth/AuthProvider.js";
 
 import LiveStoreWorker from "./livestore.worker?worker";
@@ -115,11 +116,20 @@ const NotebookApp: React.FC<NotebookAppProps> = () => {
 
 // Animation wrapper with minimum loading time and animation completion
 const AnimatedLiveStoreApp: React.FC = () => {
+  const { authState } = useAuth();
   const [isLoading, setIsLoading] = useState(true);
+  const [shouldShowAnimation, setShouldShowAnimation] = useState(false);
 
   const [liveStoreReady, setLiveStoreReady] = useState(false);
   const [portalAnimationComplete, setPortalAnimationComplete] = useState(false);
   const [portalReady, setPortalReady] = useState(false);
+
+  // Show loading animation only after auth confirmation
+  useEffect(() => {
+    if (authState.valid) {
+      setShouldShowAnimation(true);
+    }
+  }, [authState.valid]);
 
   // Update static loading screen stage when LiveStore is ready
   useEffect(() => {
@@ -153,8 +163,8 @@ const AnimatedLiveStoreApp: React.FC = () => {
 
   return (
     <>
-      {/* Loading screen overlay - fixed position to prevent layout shift */}
-      {isLoading && (
+      {/* Loading screen overlay */}
+      {shouldShowAnimation && isLoading && (
         <div className="fixed inset-0 z-50 overflow-hidden">
           <Suspense fallback={<div className="min-h-screen bg-white" />}>
             <NotebookLoadingScreen

--- a/src/components/auth/AuthGuard.tsx
+++ b/src/components/auth/AuthGuard.tsx
@@ -39,7 +39,7 @@ export const AuthGuard: React.FC<AuthGuardProps> = ({ children, fallback }) => {
     return () => window.removeEventListener("message", handleMessage);
   }, []);
 
-  // Show loading state
+  // Auth loading state
   if (isLoading) {
     return (
       <LoadingState
@@ -51,7 +51,7 @@ export const AuthGuard: React.FC<AuthGuardProps> = ({ children, fallback }) => {
     );
   }
 
-  // Show error state if authentication failed or auth expired
+  // Auth error state
   if ((error && !isAuthenticated) || authExpiredError) {
     return (
       <div className="bg-background flex min-h-screen items-center justify-center">
@@ -84,7 +84,7 @@ export const AuthGuard: React.FC<AuthGuardProps> = ({ children, fallback }) => {
     );
   }
 
-  // Show sign-in form if not authenticated
+  // Login form
   if (!isAuthenticated) {
     return (
       fallback || (
@@ -123,6 +123,6 @@ export const AuthGuard: React.FC<AuthGuardProps> = ({ children, fallback }) => {
     );
   }
 
-  // Show authenticated content
+  // Render authenticated content
   return <>{children}</>;
 };


### PR DESCRIPTION
Only show loading animation once we confirm user is authenticated. This prevents showing notebook loading for users who will see login.