### PR TITLE
Fix auth token refresh causing LiveStore restarts

### DIFF
--- a/src/components/auth/AuthGuard.tsx
+++ b/src/components/auth/AuthGuard.tsx
@@ -16,7 +16,7 @@ export const AuthGuard: React.FC<AuthGuardProps> = ({ children, fallback }) => {
   const isLoading = !authState.valid && authState.loading;
   const error =
     !authState.valid && authState.error ? authState.error.message : undefined;
-  const [authExpiredError, setAuthExpiredError] = useState<string | null>(null);
+
   const [loginError, setLoginError] = useState<string | null>(null);
   const [isButtonHovered, setIsButtonHovered] = useState(false);
 
@@ -26,18 +26,6 @@ export const AuthGuard: React.FC<AuthGuardProps> = ({ children, fallback }) => {
       updateLoadingStage("checking-auth");
     }
   }, [isLoading]);
-
-  // Listen for authentication errors from LiveStore
-  useEffect(() => {
-    const handleMessage = (event: MessageEvent) => {
-      if (event.data?.type === "AUTH_ERROR") {
-        setAuthExpiredError(event.data.message);
-      }
-    };
-
-    window.addEventListener("message", handleMessage);
-    return () => window.removeEventListener("message", handleMessage);
-  }, []);
 
   // Auth loading state
   if (isLoading) {
@@ -52,33 +40,15 @@ export const AuthGuard: React.FC<AuthGuardProps> = ({ children, fallback }) => {
   }
 
   // Auth error state
-  if ((error && !isAuthenticated) || authExpiredError) {
+  if (error && !isAuthenticated) {
     return (
       <div className="bg-background flex min-h-screen items-center justify-center">
         <div className="max-w-md text-center">
           <div className="text-foreground mb-2 text-lg font-semibold">
             Authentication Required
           </div>
-          <div className="mb-4 text-sm text-red-600">
-            {authExpiredError || error}
-          </div>
-          {authExpiredError && (
-            <div className="text-muted-foreground mb-4 text-xs">
-              Your session has expired. Please sign in again to continue.
-            </div>
-          )}
+          <div className="mb-4 text-sm text-red-600">{error}</div>
           <LoginPrompt error={loginError} setError={setLoginError} />
-          {authExpiredError && (
-            <button
-              onClick={() => {
-                setAuthExpiredError(null);
-                window.location.reload();
-              }}
-              className="mt-2 rounded-md bg-gray-200 px-4 py-2 text-sm hover:bg-gray-300"
-            >
-              Reload Page
-            </button>
-          )}
         </div>
       </div>
     );

--- a/src/components/auth/AuthRedirect.tsx
+++ b/src/components/auth/AuthRedirect.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { getOpenIdService } from "../../services/openid";
+import { useAuth } from "./AuthProvider";
 import { Button } from "../ui/button";
 import {
   Card,
@@ -22,6 +23,7 @@ const AuthRedirect: React.FC = () => {
   const [error, setError] = useState<Error | null>(null);
   const [isDirectAccess, setIsDirectAccess] = useState(false);
   const navigate = useNavigate();
+  const { refreshAuthState } = useAuth();
 
   useEffect(() => {
     // Remove the static loading screen so our component UI is visible
@@ -42,6 +44,8 @@ const AuthRedirect: React.FC = () => {
     // Legitimate OIDC callback - process it
     const subscription = openIdService.handleRedirect().subscribe({
       complete: () => {
+        // Refresh auth state with new user info before navigation
+        refreshAuthState();
         redirectHelper.navigateToSavedNotebook(navigate);
       },
       error: (error) => {
@@ -54,7 +58,7 @@ const AuthRedirect: React.FC = () => {
         subscription.unsubscribe();
       }
     };
-  }, [openIdService, navigate]);
+  }, [openIdService, navigate, refreshAuthState]);
 
   // Direct access case - show informative message
   if (isDirectAccess) {


### PR DESCRIPTION
- Decouple auth token refresh from LiveStore sync payload
- AuthProvider now stable: only updates on login/logout, not token refresh
- Background token refresh via keepFresh() without reactive chain disruption
- syncPayload uses getter for authToken to avoid object reference changes
- REST APIs get fresh tokens while LiveStore stays connected
- Remove debugging logs from production code

Resolves page reload/restart issues during token lifecycle.