### PR TITLE
Fix Anaconda auth compat by disabling UserInfo endpoint

### DIFF
--- a/src/auth/oidc-config.ts
+++ b/src/auth/oidc-config.ts
@@ -34,7 +34,7 @@ export const createOidcConfig = (): AuthProviderProps => {
 
     // Additional OIDC settings
     response_type: "code",
-    loadUserInfo: true,
+    loadUserInfo: false,
 
     // Silent refresh configuration
     accessTokenExpiringNotificationTimeInSeconds: 60, // Notify 1 minute before expiry


### PR DESCRIPTION
Problem: Authentication fails with "subject from UserInfo response does not match subject in ID Token" error when using Anaconda's OAuth provider.

Root cause: Anaconda's UserInfo endpoint returns non-standard OIDC claim structure with `identity.id` instead of the expected `sub` field. The oidc-client-ts library validates that userInfoClaims.sub === idTokenClaims.sub, but this comparison fails.

Solution: Set loadUserInfo: false in OIDC configuration. The ID token already contains all necessary user claims (sub, email, given_name, family_name), making the UserInfo endpoint call redundant.