### PR TITLE
Fix OIDC callback processing with manual token exchange

### DIFF
--- a/src/auth/oidc-config.ts
+++ b/src/auth/oidc-config.ts
@@ -29,8 +29,8 @@ export const createOidcConfig = (): AuthProviderProps => {
     // Persist auth state across browser sessions
     userStore: new WebStorageStateStore({ store: window.localStorage }),
 
-    // Temporarily remove onSigninCallback to test if it's interfering with state updates
-    // The URL cleanup might be happening before React state updates
+    // Manual callback processing: onSigninCallback is handled by /oidc route
+    // This provides better control over the authentication flow
 
     // Additional OIDC settings
     response_type: "code",

--- a/src/pages/OidcCallbackPage.tsx
+++ b/src/pages/OidcCallbackPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { useAuth as useOidcAuth } from "react-oidc-context";
 import { UserManager } from "oidc-client-ts";
-import { createOidcConfig } from "@/auth/oidc-config";
+import { WebStorageStateStore } from "oidc-client-ts";
 
 // Manual OIDC callback processing page
 export const OidcCallbackPage: React.FC = () => {
@@ -35,9 +35,17 @@ export const OidcCallbackPage: React.FC = () => {
       setProcessedCallback(true);
 
       try {
-        // Create UserManager with same config as AuthProvider
-        const config = createOidcConfig();
-        const userManager = new UserManager(config);
+        // Create UserManager settings directly (compatible with UserManagerSettings)
+        const userManagerSettings = {
+          authority: import.meta.env.VITE_AUTH_URI!,
+          client_id: import.meta.env.VITE_AUTH_CLIENT_ID!,
+          redirect_uri: import.meta.env.VITE_AUTH_REDIRECT_URI!,
+          scope: "openid profile email offline_access",
+          response_type: "code",
+          loadUserInfo: false,
+          userStore: new WebStorageStateStore({ store: window.localStorage }),
+        };
+        const userManager = new UserManager(userManagerSettings);
 
         console.log("🔍 OidcCallbackPage: Calling signinCallback");
         const user = await userManager.signinCallback();

--- a/src/pages/OidcCallbackPage.tsx
+++ b/src/pages/OidcCallbackPage.tsx
@@ -1,16 +1,96 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useAuth as useOidcAuth } from "react-oidc-context";
+import { UserManager } from "oidc-client-ts";
+import { createOidcConfig } from "@/auth/oidc-config";
 
-// Simple OIDC callback page
+// Manual OIDC callback processing page
 export const OidcCallbackPage: React.FC = () => {
   const auth = useOidcAuth();
+  const [processing, setProcessing] = useState(false);
+  const [processedCallback, setProcessedCallback] = useState(false);
 
   useEffect(() => {
-    if (auth.isAuthenticated) {
-      console.log("🔍 OidcCallbackPage: Authenticated, redirecting to home");
+    const processCallback = async () => {
+      if (processing || processedCallback) return;
+
+      const urlParams = new URLSearchParams(window.location.search);
+      const code = urlParams.get("code");
+      const state = urlParams.get("state");
+
+      if (!code || !state) {
+        console.log(
+          "🔍 OidcCallbackPage: No callback params, redirecting home"
+        );
+        window.location.href = "/";
+        return;
+      }
+
+      console.log("🔍 OidcCallbackPage: Processing callback manually", {
+        hasCode: !!code,
+        hasState: !!state,
+        url: window.location.href,
+      });
+
+      setProcessing(true);
+      setProcessedCallback(true);
+
+      try {
+        // Create UserManager with same config as AuthProvider
+        const config = createOidcConfig();
+        const userManager = new UserManager(config);
+
+        console.log("🔍 OidcCallbackPage: Calling signinCallback");
+        const user = await userManager.signinCallback();
+
+        console.log("🔍 OidcCallbackPage: Callback successful", {
+          user: user
+            ? {
+                profile: user.profile,
+                hasAccessToken: !!user.access_token,
+                hasIdToken: !!user.id_token,
+              }
+            : null,
+        });
+
+        // Clean URL and redirect
+        window.history.replaceState({}, document.title, "/");
+        window.location.href = "/";
+      } catch (error) {
+        console.error("🔍 OidcCallbackPage: Callback failed", error);
+        // On error, redirect home
+        setTimeout(() => {
+          window.location.href = "/";
+        }, 2000);
+      }
+    };
+
+    processCallback();
+  }, [processing, processedCallback]);
+
+  // Fallback for auth state changes from react-oidc-context
+  useEffect(() => {
+    if (
+      auth.user &&
+      auth.user.access_token &&
+      auth.user.id_token &&
+      !processing
+    ) {
+      console.log(
+        "🔍 OidcCallbackPage: Auth context updated with user, redirecting"
+      );
       window.location.href = "/";
     }
-  }, [auth.isAuthenticated]);
+  }, [auth.user, processing]);
+
+  // Fallback redirect after 15 seconds if stuck
+  useEffect(() => {
+    const fallbackTimer = setTimeout(() => {
+      console.warn("🔍 OidcCallbackPage: Fallback redirect after timeout");
+      window.location.href = "/";
+    }, 15000);
+
+    return () => clearTimeout(fallbackTimer);
+  }, []);
 
   if (auth.error) {
     return (
@@ -41,6 +121,11 @@ export const OidcCallbackPage: React.FC = () => {
           <p className="text-muted-foreground text-sm">
             Processing authentication
           </p>
+          <div className="text-muted-foreground mt-4 text-xs">
+            Processing: {processing ? "Yes" : "No"} | Authenticated:{" "}
+            {auth.isAuthenticated ? "Yes" : "No"} | Has User:{" "}
+            {auth.user ? "Yes" : "No"}
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Problem: react-oidc-context automatic callback processing fails silently, causing users to get stuck on callback page without authentication completing.

Solution: Implement manual callback processing on /oidc route using UserManager.signinCallback() to explicitly exchange authorization code for tokens.

Changes:
- Update OidcCallbackPage to detect callback parameters and manually process token exchange
- Add comprehensive logging for callback flow debugging
- Remove onSigninCallback from OIDC config to avoid conflicts with manual processing
- Add fallback timeouts and error handling for robust callback flow

Impact: Fixes authentication flow in both local development and production environments.