### PR TITLE
Cleanup old testing bits

### DIFF
--- a/src/auth/AuthGuard.tsx
+++ b/src/auth/AuthGuard.tsx
@@ -6,10 +6,6 @@ import { RuntLogo } from "../components/logo";
 import { LoadingState } from "../components/loading/LoadingState";
 import { useSpring, animated } from "@react-spring/web";
 
-// DEV MODE: Force login screen for design testing
-// Set to true to preview login screen locally
-const FORCE_LOGIN_SCREEN = false;
-
 interface AuthGuardProps {
   children: React.ReactNode;
   fallback?: React.ReactNode;
@@ -198,8 +194,7 @@ export const AuthGuard: React.FC<AuthGuardProps> = ({ children, fallback }) => {
     );
   }
 
-  // Show sign-in form if not authenticated OR if forced for design testing
-  if (!isAuthenticated || FORCE_LOGIN_SCREEN) {
+  if (!isAuthenticated) {
     return renderLoginForm();
   }
 

--- a/src/auth/openid.ts
+++ b/src/auth/openid.ts
@@ -59,7 +59,7 @@ export type RedirectUrls = {
 export enum LocalStorageKey {
   RequestState = "openid_request_state",
   Tokens = "openid_tokens",
-  LocalAuthRegistration = "local-auth-registration", // Keep in sync with AuthorizePage.tsx
+  LocalAuthRegistration = "local-auth-registration",
 }
 
 const OPENID_SCOPES = "openid email profile offline_access";

--- a/src/pages/AuthorizePage.tsx
+++ b/src/pages/AuthorizePage.tsx
@@ -12,6 +12,7 @@ import {
 import { RuntLogo } from "../components/logo";
 import { removeStaticLoadingScreen } from "@/util/domUpdates";
 import { useSpring, animated } from "@react-spring/web";
+import { LocalStorageKey } from "@/auth/openid";
 
 interface RegisterFormData {
   firstName: string;
@@ -19,7 +20,7 @@ interface RegisterFormData {
   email: string;
 }
 
-const LOCAL_STORAGE_KEY = "local-auth-registration"; // Keep in sync with openid.ts
+const LOCAL_STORAGE_KEY = LocalStorageKey.LocalAuthRegistration;
 
 const AuthorizePage: React.FC = () => {
   const [searchParams] = useSearchParams();


### PR DESCRIPTION
Toss the `FORCE_LOGIN_SCREEN` bits from way back, rely on the enum to pluck the local storage key.