### PR TITLE
reduce header clutter

### DIFF
--- a/src/components/notebooks/NotebookPage.tsx
+++ b/src/components/notebooks/NotebookPage.tsx
@@ -22,7 +22,7 @@ import { RuntimeHealthIndicatorButton } from "../notebook/RuntimeHealthIndicator
 import { RuntimeHelper } from "../notebook/RuntimeHelper";
 import { DelayedSpinner } from "../outputs/shared-with-iframe/SuspenseSpinner";
 import { useTrpc } from "../TrpcProvider";
-import { Badge } from "../ui/badge";
+
 import { Button } from "../ui/button";
 import { TitleEditor } from "./notebook/TitleEditor";
 import { SharingModal } from "./SharingModal";
@@ -177,44 +177,10 @@ export const NotebookPage: React.FC = () => {
                 onTitleSaved={refetch}
                 canEdit={canEdit}
               />
-
-              {/* Tags - Simplified */}
-              <div className="flex items-center gap-2">
-                {notebook.tags?.slice(0, 3).map((tag) => (
-                  <TagBadge key={tag.id} tag={tag} className="text-xs" />
-                ))}
-                {notebook.tags && notebook.tags.length > 3 && (
-                  <Badge
-                    variant="outline"
-                    className="px-1.5 py-0.5 text-xs text-gray-500"
-                  >
-                    +{notebook.tags.length - 3}
-                  </Badge>
-                )}
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => setIsTagSelectionOpen(true)}
-                  className="h-6 px-2 text-xs text-gray-500 hover:text-gray-700"
-                >
-                  <Tag className="mr-1 h-3 w-3" />
-                  {!notebook.tags || notebook.tags.length === 0
-                    ? "Add tags"
-                    : "Edit"}
-                </Button>
-              </div>
             </div>
 
             {/* Right side - Simplified */}
             <div className="flex items-center gap-3">
-              {/* Permission badge - smaller and less prominent */}
-              <Badge
-                variant="secondary"
-                className="bg-gray-100 px-2 py-1 text-xs text-gray-600"
-              >
-                {(notebook.myPermission || "NONE").toLowerCase()}
-              </Badge>
-
               {import.meta.env.DEV && <DebugModeToggle />}
 
               <ErrorBoundary fallback={<div>Error loading user profile</div>}>
@@ -224,55 +190,80 @@ export const NotebookPage: React.FC = () => {
           </div>
 
           {/* Metadata - Simplified */}
-          <div className="mt-3 flex items-center gap-4 text-xs text-gray-500">
-            {/* Owner name without label */}
-            <div className="flex items-center gap-1.5">
-              <User className="h-3 w-3" />
-              <span>
-                {notebook.owner?.givenName && notebook.owner?.familyName
-                  ? `${notebook.owner.givenName} ${notebook.owner.familyName}`
-                  : "Unknown Owner"}
-              </span>
-            </div>
+          <div className="mt-3 flex items-center justify-between text-xs text-gray-500">
+            <div className="flex items-center gap-4">
+              {/* Owner name without label */}
+              <div className="flex items-center gap-1.5">
+                <User className="h-3 w-3" />
+                <span>
+                  {notebook.owner?.givenName && notebook.owner?.familyName
+                    ? `${notebook.owner.givenName} ${notebook.owner.familyName}`
+                    : "Unknown Owner"}
+                </span>
+              </div>
 
-            {/* Collaborators count with share button */}
-            {notebook.collaborators && notebook.collaborators.length > 0 && (
-              <div className="flex items-center gap-2">
-                <div className="flex items-center gap-1.5">
-                  <Users className="h-3 w-3" />
-                  <span>
-                    {notebook.collaborators.length}{" "}
-                    {notebook.collaborators.length === 1
-                      ? "collaborator"
-                      : "collaborators"}
-                  </span>
+              {/* Collaborators count with share button */}
+              {notebook.collaborators && notebook.collaborators.length > 0 && (
+                <div className="flex items-center gap-2">
+                  <div className="flex items-center gap-1.5">
+                    <Users className="h-3 w-3" />
+                    <span>
+                      {notebook.collaborators.length}{" "}
+                      {notebook.collaborators.length === 1
+                        ? "collaborator"
+                        : "collaborators"}
+                    </span>
+                  </div>
+                  {canEdit && (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => setIsSharingModalOpen(true)}
+                      className="h-5 px-2 text-xs text-gray-400 hover:text-gray-600"
+                    >
+                      Share
+                    </Button>
+                  )}
                 </div>
-                {canEdit && (
+              )}
+
+              {/* Show share button even when no collaborators */}
+              {(!notebook.collaborators ||
+                notebook.collaborators.length === 0) &&
+                canEdit && (
                   <Button
                     variant="ghost"
                     size="sm"
                     onClick={() => setIsSharingModalOpen(true)}
                     className="h-5 px-2 text-xs text-gray-400 hover:text-gray-600"
                   >
+                    <Users className="mr-1.5 h-3 w-3" />
                     Share
                   </Button>
                 )}
-              </div>
-            )}
+            </div>
 
-            {/* Show share button even when no collaborators */}
-            {(!notebook.collaborators || notebook.collaborators.length === 0) &&
-              canEdit && (
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => setIsSharingModalOpen(true)}
-                  className="h-5 px-2 text-xs text-gray-400 hover:text-gray-600"
-                >
-                  <Users className="mr-1.5 h-3 w-3" />
-                  Share
-                </Button>
-              )}
+            {/* Tags - Right aligned */}
+            <div className="flex items-center gap-1">
+              {notebook.tags?.map((tag) => (
+                <TagBadge
+                  key={tag.id}
+                  tag={tag}
+                  className="px-1.5 py-0.5 text-[10px]"
+                />
+              ))}
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => setIsTagSelectionOpen(true)}
+                className="h-4 px-1.5 text-[10px] text-gray-400 hover:text-gray-600"
+              >
+                <Tag className="mr-1 h-2.5 w-2.5" />
+                {!notebook.tags || notebook.tags.length === 0
+                  ? "Add tags"
+                  : "Edit"}
+              </Button>
+            </div>
           </div>
         </div>
       </div>

--- a/src/components/notebooks/NotebookPage.tsx
+++ b/src/components/notebooks/NotebookPage.tsx
@@ -1,7 +1,7 @@
 import { useDebug } from "@/components/debug/debug-mode.js";
 import { cn } from "@/lib/utils";
 import { useQuery } from "@tanstack/react-query";
-import { ArrowLeft, Share2, Tag, User, Users } from "lucide-react";
+import { ArrowLeft, Tag, User, Users } from "lucide-react";
 import React, { Suspense, useEffect, useState } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 import { Link, useLocation, useNavigate, useParams } from "react-router-dom";
@@ -207,18 +207,6 @@ export const NotebookPage: React.FC = () => {
 
             {/* Right side - Simplified */}
             <div className="flex items-center gap-3">
-              {/* Share button - only show if can edit */}
-              {canEdit && (
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => setIsSharingModalOpen(true)}
-                  className="text-gray-600 hover:text-gray-900"
-                >
-                  <Share2 className="h-4 w-4" />
-                </Button>
-              )}
-
               {/* Permission badge - smaller and less prominent */}
               <Badge
                 variant="secondary"
@@ -237,7 +225,7 @@ export const NotebookPage: React.FC = () => {
 
           {/* Metadata - Simplified */}
           <div className="mt-3 flex items-center gap-4 text-xs text-gray-500">
-            {/* Owner - more subtle */}
+            {/* Owner name without label */}
             <div className="flex items-center gap-1.5">
               <User className="h-3 w-3" />
               <span>
@@ -247,18 +235,44 @@ export const NotebookPage: React.FC = () => {
               </span>
             </div>
 
-            {/* Collaborators count - more subtle */}
+            {/* Collaborators count with share button */}
             {notebook.collaborators && notebook.collaborators.length > 0 && (
-              <div className="flex items-center gap-1.5">
-                <Users className="h-3 w-3" />
-                <span>
-                  {notebook.collaborators.length}{" "}
-                  {notebook.collaborators.length === 1
-                    ? "collaborator"
-                    : "collaborators"}
-                </span>
+              <div className="flex items-center gap-2">
+                <div className="flex items-center gap-1.5">
+                  <Users className="h-3 w-3" />
+                  <span>
+                    {notebook.collaborators.length}{" "}
+                    {notebook.collaborators.length === 1
+                      ? "collaborator"
+                      : "collaborators"}
+                  </span>
+                </div>
+                {canEdit && (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => setIsSharingModalOpen(true)}
+                    className="h-5 px-2 text-xs text-gray-400 hover:text-gray-600"
+                  >
+                    Share
+                  </Button>
+                )}
               </div>
             )}
+
+            {/* Show share button even when no collaborators */}
+            {(!notebook.collaborators || notebook.collaborators.length === 0) &&
+              canEdit && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setIsSharingModalOpen(true)}
+                  className="h-5 px-2 text-xs text-gray-400 hover:text-gray-600"
+                >
+                  <Users className="mr-1.5 h-3 w-3" />
+                  Share
+                </Button>
+              )}
           </div>
         </div>
       </div>


### PR DESCRIPTION
Reduced the header clutter by moving "Share" next to the collaborator count, moving the user info to the right of the tags.

Before:

<img width="800" height="133" alt="image" src="https://github.com/user-attachments/assets/11f9243d-e1fd-498f-963e-19d194b29c63" />


After:

<img width="817" height="217" alt="image" src="https://github.com/user-attachments/assets/f220caaf-d47e-46df-9ebf-07eb65a66d4e" />


If you toss our current presence, context, and AI controls it also gets a lot cleaner. Two alternates:

<img width="782" height="314" alt="image" src="https://github.com/user-attachments/assets/b81ba094-8f36-4ffa-a200-a89a72284323" />

<img width="836" height="280" alt="image" src="https://github.com/user-attachments/assets/310ab8e9-65a8-4005-b58e-815d758693a7" />

