### PR TITLE
Refactor sidebar to use declarative panel components

### DIFF
--- a/src/components/debug/DebugPanel.tsx
+++ b/src/components/debug/DebugPanel.tsx
@@ -4,7 +4,7 @@ import { queryDb, sql, Schema } from "@livestore/livestore";
 
 import { tables, events, queries } from "@/schema";
 import { schema } from "../../schema.js";
-import { Bug, Database } from "lucide-react";
+import { Database } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
 const useAvailableTables = () => {
@@ -73,13 +73,6 @@ const DebugPanel: React.FC = () => {
 
   return (
     <div className="bg-muted/5 w-full overflow-y-auto">
-      <div className="bg-card border-b pb-3">
-        <h3 className="flex items-center gap-2 text-sm font-semibold">
-          <Bug className="h-4 w-4" />
-          Runt Debug Panel
-        </h3>
-      </div>
-
       <a
         target="_blank"
         rel="noopener noreferrer"

--- a/src/components/debug/DebugPanel.tsx
+++ b/src/components/debug/DebugPanel.tsx
@@ -73,7 +73,7 @@ const DebugPanel: React.FC = () => {
 
   return (
     <div className="bg-muted/5 w-full overflow-y-auto">
-      <div className="bg-card border-b p-4">
+      <div className="bg-card border-b pb-3">
         <h3 className="flex items-center gap-2 text-sm font-semibold">
           <Bug className="h-4 w-4" />
           Runt Debug Panel
@@ -84,13 +84,13 @@ const DebugPanel: React.FC = () => {
         target="_blank"
         rel="noopener noreferrer"
         href={`${window.location.protocol}//${window.location.hostname}${window.location.port ? `:${window.location.port}` : ""}/_livestore/web/${store.storeId}/${store.clientSession.clientId}/${store.sessionId}/default`}
-        className="hover:bg-muted flex items-center gap-1 border-b px-4 py-2 text-sm text-blue-500 hover:underline"
+        className="hover:bg-muted flex items-center gap-1 border-b py-2 text-sm text-blue-500 hover:underline"
       >
         <Database className="size-4" />
         LiveStore DevTools →
       </a>
 
-      <div className="space-y-4 p-4">
+      <div className="space-y-4 pt-4">
         <DebugVersion />
         {/* Available Tables */}
         <div>

--- a/src/components/notebook/NotebookSidebar.tsx
+++ b/src/components/notebook/NotebookSidebar.tsx
@@ -1,38 +1,26 @@
-import React, { useState, Suspense } from "react";
-import { ErrorBoundary } from "react-error-boundary";
+import React, { useState } from "react";
 import { Button } from "@/components/ui/button";
-import { TagBadge } from "@/components/notebooks/TagBadge";
-import { TagSelectionDialog } from "@/components/notebooks/TagSelectionDialog";
-import { ContextSelectionModeButton } from "@/components/notebook/ContextSelectionModeButton";
-
-import { RuntimeHealthIndicator } from "@/components/notebook/RuntimeHealthIndicator";
 import { useRuntimeHealth } from "@/hooks/useRuntimeHealth";
 import type { NotebookProcessed } from "@/components/notebooks/types";
 import { RuntSidebarLogo } from "@/components/logo/RuntSidebarLogo";
-import { GitCommitHash } from "@/components/notebook/GitCommitHash";
 import { Link } from "react-router-dom";
 
-// Icons
+// Panel Components
 import {
-  Tag,
-  ListChecks,
-  MonitorCheck,
-  MonitorOff,
-  DatabaseZap,
-  X,
-  ArrowLeft,
-  HelpCircle,
-  Star,
-  Bug,
-  ExternalLink,
-} from "lucide-react";
+  MetadataPanel,
+  AiPanel,
+  RuntimePanel,
+  HelpPanel,
+  DebugPanel,
+  type SidebarSection,
+  type SidebarPanelProps,
+} from "./sidebar-panels";
 
-// Lazy import DebugPanel only in development
-const LazyDebugPanel = React.lazy(() =>
-  import("@/components/debug/DebugPanel").then((module) => ({
-    default: module.DebugPanel,
-  }))
-);
+// Configuration
+import { getSidebarItems, getSidebarItemConfig } from "./sidebar-panels/config";
+
+// Icons
+import { X, ArrowLeft } from "lucide-react";
 
 interface NotebookSidebarProps {
   notebook: NotebookProcessed;
@@ -40,7 +28,13 @@ interface NotebookSidebarProps {
   onAiPanelToggle: (isOpen: boolean) => void;
 }
 
-type SidebarSection = "metadata" | "ai" | "runtime" | "debug" | "help";
+const PANEL_COMPONENTS: Record<SidebarSection, React.FC<SidebarPanelProps>> = {
+  metadata: MetadataPanel,
+  ai: AiPanel,
+  runtime: RuntimePanel,
+  debug: DebugPanel,
+  help: HelpPanel,
+};
 
 export const NotebookSidebar: React.FC<NotebookSidebarProps> = ({
   notebook,
@@ -50,8 +44,7 @@ export const NotebookSidebar: React.FC<NotebookSidebarProps> = ({
   const [activeSection, setActiveSection] = useState<SidebarSection | null>(
     null
   );
-  const [isTagSelectionOpen, setIsTagSelectionOpen] = useState(false);
-  const { hasActiveRuntime, runtimeHealth, activeRuntime } = useRuntimeHealth();
+  const { hasActiveRuntime, runtimeHealth } = useRuntimeHealth();
 
   const toggleSection = (section: SidebarSection) => {
     const newActiveSection = activeSection === section ? null : section;
@@ -69,48 +62,23 @@ export const NotebookSidebar: React.FC<NotebookSidebarProps> = ({
     }
   };
 
-  const handleTagsClick = () => {
-    setIsTagSelectionOpen(true);
-    setActiveSection(null);
+  const sidebarItems = getSidebarItems({
+    hasActiveRuntime,
+    runtimeHealth,
+    activeSection,
+    isDev: import.meta.env.DEV,
+  });
+
+  const renderPanelContent = () => {
+    if (!activeSection) return null;
+
+    const PanelComponent = PANEL_COMPONENTS[activeSection];
+    const panelProps: SidebarPanelProps = { notebook, onUpdate };
+
+    return <PanelComponent {...panelProps} />;
   };
 
-  const sidebarItems = [
-    {
-      id: "metadata" as SidebarSection,
-      icon: Tag,
-      tooltip: "Tags & Metadata",
-    },
-    ...(hasActiveRuntime ||
-    runtimeHealth !== "healthy" ||
-    activeSection === "runtime"
-      ? [
-          {
-            id: "runtime" as SidebarSection,
-            icon: hasActiveRuntime ? MonitorCheck : MonitorOff,
-            tooltip: "Runtime",
-          },
-        ]
-      : []),
-    {
-      id: "ai" as SidebarSection,
-      icon: ListChecks,
-      tooltip: "AI Context Controls",
-    },
-    ...(import.meta.env.DEV
-      ? [
-          {
-            id: "debug" as SidebarSection,
-            icon: DatabaseZap,
-            tooltip: "LiveStore Debug",
-          },
-        ]
-      : []),
-    {
-      id: "help" as SidebarSection,
-      icon: HelpCircle,
-      tooltip: "Help & Shortcuts",
-    },
-  ];
+  const activeItem = activeSection ? getSidebarItemConfig(activeSection) : null;
 
   return (
     <>
@@ -163,7 +131,9 @@ export const NotebookSidebar: React.FC<NotebookSidebarProps> = ({
           {activeSection !== "ai" && (
             <div
               className="fixed inset-0 z-30 bg-black/20"
-              onClick={() => setActiveSection(null)}
+              onClick={() => {
+                setActiveSection(null);
+              }}
             />
           )}
 
@@ -176,13 +146,7 @@ export const NotebookSidebar: React.FC<NotebookSidebarProps> = ({
             }
           >
             <div className="flex items-center justify-between border-b px-4 py-3">
-              <h3 className="font-medium text-gray-900">
-                {activeSection === "metadata" && "Tags & Metadata"}
-                {activeSection === "ai" && "AI Context Controls"}
-                {activeSection === "runtime" && "Runtime Configuration"}
-                {activeSection === "debug" && "Debug Panel"}
-                {activeSection === "help" && "Help & Keyboard Shortcuts"}
-              </h3>
+              <h3 className="font-medium text-gray-900">{activeItem?.title}</h3>
               <Button
                 variant="ghost"
                 size="sm"
@@ -198,250 +162,10 @@ export const NotebookSidebar: React.FC<NotebookSidebarProps> = ({
               </Button>
             </div>
 
-            <div className="p-4">
-              {activeSection === "metadata" && (
-                <div className="space-y-4">
-                  <div>
-                    <h4 className="mb-3 text-sm font-medium text-gray-700">
-                      Current Tags
-                    </h4>
-                    <div className="mb-4 flex flex-wrap gap-2">
-                      {notebook.tags?.length ? (
-                        notebook.tags.map((tag) => (
-                          <TagBadge key={tag.id} tag={tag} />
-                        ))
-                      ) : (
-                        <span className="text-sm text-gray-500">
-                          No tags assigned
-                        </span>
-                      )}
-                    </div>
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={handleTagsClick}
-                      className="w-full"
-                    >
-                      <Tag className="mr-2 h-4 w-4" />
-                      {notebook.tags?.length ? "Edit Tags" : "Add Tags"}
-                    </Button>
-                  </div>
-                </div>
-              )}
-
-              {activeSection === "ai" && (
-                <div className="space-y-6">
-                  <div>
-                    <h4 className="mb-3 text-sm font-medium text-gray-700">
-                      Context Selection
-                    </h4>
-                    <p className="mb-3 text-xs text-gray-500">
-                      Control which cells are included in AI context
-                    </p>
-                    <ContextSelectionModeButton />
-                  </div>
-
-                  <div className="border-t pt-4">
-                    <h4 className="mb-3 text-sm font-medium text-gray-700">
-                      AI Settings
-                    </h4>
-                    <p className="text-xs text-gray-500">
-                      Additional AI configuration options will be added here
-                    </p>
-                  </div>
-                </div>
-              )}
-
-              {activeSection === "runtime" && (
-                <div className="space-y-4">
-                  <div>
-                    <h4 className="mb-3 text-sm font-medium text-gray-700">
-                      Runtime Status
-                    </h4>
-                    <div className="space-y-2">
-                      <div className="flex items-center justify-between">
-                        <span className="text-xs text-gray-600">
-                          Connection
-                        </span>
-                        <RuntimeHealthIndicator showStatus />
-                      </div>
-                      {hasActiveRuntime && (
-                        <div className="flex items-center justify-between">
-                          <span className="text-xs text-gray-600">Type</span>
-                          <span className="font-mono text-xs">
-                            {activeRuntime?.runtimeType ?? "unknown"}
-                          </span>
-                        </div>
-                      )}
-                    </div>
-                  </div>
-
-                  {hasActiveRuntime && activeRuntime && (
-                    <div className="border-t pt-4">
-                      <h4 className="mb-2 text-xs font-medium text-gray-700">
-                        Runtime Details
-                      </h4>
-                      <div className="space-y-1 text-xs">
-                        <div className="flex justify-between">
-                          <span className="text-gray-600">Session:</span>
-                          <code className="rounded bg-gray-100 px-1 text-xs">
-                            {activeRuntime.sessionId.slice(-8)}
-                          </code>
-                        </div>
-                        <div className="flex justify-between">
-                          <span className="text-gray-600">Status:</span>
-                          <span
-                            className={`text-xs font-medium ${
-                              activeRuntime.status === "ready"
-                                ? "text-green-600"
-                                : activeRuntime.status === "busy"
-                                  ? "text-amber-600"
-                                  : "text-red-600"
-                            }`}
-                          >
-                            {activeRuntime.status === "ready"
-                              ? "Ready"
-                              : activeRuntime.status === "busy"
-                                ? "Busy"
-                                : activeRuntime.status.charAt(0).toUpperCase() +
-                                  activeRuntime.status.slice(1)}
-                          </span>
-                        </div>
-                      </div>
-                    </div>
-                  )}
-
-                  {!hasActiveRuntime && (
-                    <div className="border-t pt-4">
-                      <div className="space-y-2">
-                        <p className="text-xs text-gray-500">
-                          Start a runtime to execute code cells.
-                        </p>
-                        <p className="text-xs text-gray-500">
-                          Setup instructions will be available here.
-                        </p>
-                      </div>
-                    </div>
-                  )}
-                </div>
-              )}
-
-              {activeSection === "help" && (
-                <div className="space-y-6">
-                  <div>
-                    <h4 className="mb-3 text-sm font-medium text-gray-700">
-                      Keyboard Shortcuts
-                    </h4>
-                    <div className="space-y-3 text-sm">
-                      <div className="flex justify-between">
-                        <span className="text-gray-600">Navigate cells</span>
-                        <code className="rounded bg-gray-100 px-2 py-1 text-xs">
-                          ↑↓
-                        </code>
-                      </div>
-                      <div className="flex justify-between">
-                        <span className="text-gray-600">Run & next</span>
-                        <code className="rounded bg-gray-100 px-2 py-1 text-xs">
-                          Shift+Enter
-                        </code>
-                      </div>
-                      <div className="flex justify-between">
-                        <span className="text-gray-600">Run cell</span>
-                        <code className="rounded bg-gray-100 px-2 py-1 text-xs">
-                          Ctrl+Enter
-                        </code>
-                      </div>
-                    </div>
-                  </div>
-
-                  <div className="border-t pt-4">
-                    <h4 className="mb-3 text-sm font-medium text-gray-700">
-                      Getting Started
-                    </h4>
-                    <p className="text-xs text-gray-500">
-                      Pick a cell type above to start experimenting with
-                      real-time collaborative computing.
-                    </p>
-                  </div>
-
-                  <div className="border-t pt-4">
-                    <h4 className="mb-3 text-sm font-medium text-gray-700">
-                      About Anode
-                    </h4>
-                    <div className="space-y-3">
-                      <div className="flex flex-col space-y-2">
-                        <a
-                          href="https://github.com/runtimed/anode"
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="flex items-center gap-2 rounded px-2 py-1.5 text-xs hover:bg-gray-100"
-                        >
-                          <Star className="h-3 w-3" />
-                          <span>Star us on GitHub</span>
-                          <ExternalLink className="h-3 w-3 opacity-60" />
-                        </a>
-                        <a
-                          href="https://github.com/runtimed/anode/issues"
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="flex items-center gap-2 rounded px-2 py-1.5 text-xs hover:bg-gray-100"
-                        >
-                          <Bug className="h-3 w-3" />
-                          <span>Report a bug</span>
-                          <ExternalLink className="h-3 w-3 opacity-60" />
-                        </a>
-                      </div>
-                      <div className="border-t pt-2">
-                        <div className="flex items-center justify-between text-xs">
-                          <span className="text-gray-600">Build:</span>
-                          <GitCommitHash />
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              )}
-
-              {activeSection === "debug" && import.meta.env.DEV && (
-                <div className="h-full">
-                  <div className="mb-3">
-                    <p className="text-xs text-gray-500">
-                      LiveStore database debugging and inspection tools.
-                    </p>
-                  </div>
-                  <Suspense
-                    fallback={
-                      <div className="p-4 text-xs text-gray-500">
-                        Loading debug panel...
-                      </div>
-                    }
-                  >
-                    <ErrorBoundary
-                      fallback={
-                        <div className="text-sm text-red-500">
-                          Error rendering debug panel
-                        </div>
-                      }
-                    >
-                      <div className="w-full max-w-full overflow-hidden">
-                        <LazyDebugPanel />
-                      </div>
-                    </ErrorBoundary>
-                  </Suspense>
-                </div>
-              )}
-            </div>
+            <div className="p-4">{renderPanelContent()}</div>
           </div>
         </>
       )}
-
-      {/* Existing dialogs */}
-      <TagSelectionDialog
-        notebookId={notebook.id}
-        isOpen={isTagSelectionOpen}
-        onClose={() => setIsTagSelectionOpen(false)}
-        onUpdate={onUpdate}
-      />
     </>
   );
 };

--- a/src/components/notebook/sidebar-panels/AiPanel.tsx
+++ b/src/components/notebook/sidebar-panels/AiPanel.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { ContextSelectionModeButton } from "@/components/notebook/ContextSelectionModeButton";
+import type { SidebarPanelProps } from "./types";
+
+export const AiPanel: React.FC<SidebarPanelProps> = () => {
+  return (
+    <div className="space-y-6">
+      <div>
+        <h4 className="mb-3 text-sm font-medium text-gray-700">
+          Context Selection
+        </h4>
+        <p className="mb-3 text-xs text-gray-500">
+          Control which cells are included in AI context
+        </p>
+        <ContextSelectionModeButton />
+      </div>
+
+      <div className="border-t pt-4">
+        <h4 className="mb-3 text-sm font-medium text-gray-700">AI Settings</h4>
+        <p className="text-xs text-gray-500">
+          Additional AI configuration options will be added here
+        </p>
+      </div>
+    </div>
+  );
+};

--- a/src/components/notebook/sidebar-panels/DebugPanel.tsx
+++ b/src/components/notebook/sidebar-panels/DebugPanel.tsx
@@ -1,0 +1,45 @@
+import React, { Suspense } from "react";
+import { ErrorBoundary } from "react-error-boundary";
+import type { SidebarPanelProps } from "./types";
+
+// Lazy import DebugPanel only in development
+const LazyDebugPanel = React.lazy(() =>
+  import("@/components/debug/DebugPanel").then((module) => ({
+    default: module.DebugPanel,
+  }))
+);
+
+export const DebugPanel: React.FC<SidebarPanelProps> = () => {
+  if (!import.meta.env.DEV) {
+    return null;
+  }
+
+  return (
+    <div className="h-full">
+      <div className="mb-3">
+        <p className="text-xs text-gray-500">
+          LiveStore database debugging and inspection tools.
+        </p>
+      </div>
+      <Suspense
+        fallback={
+          <div className="p-4 text-xs text-gray-500">
+            Loading debug panel...
+          </div>
+        }
+      >
+        <ErrorBoundary
+          fallback={
+            <div className="text-sm text-red-500">
+              Error rendering debug panel
+            </div>
+          }
+        >
+          <div className="w-full max-w-full overflow-hidden">
+            <LazyDebugPanel />
+          </div>
+        </ErrorBoundary>
+      </Suspense>
+    </div>
+  );
+};

--- a/src/components/notebook/sidebar-panels/DebugPanel.tsx
+++ b/src/components/notebook/sidebar-panels/DebugPanel.tsx
@@ -15,31 +15,20 @@ export const DebugPanel: React.FC<SidebarPanelProps> = () => {
   }
 
   return (
-    <div className="h-full">
-      <div className="mb-3">
-        <p className="text-xs text-gray-500">
-          LiveStore database debugging and inspection tools.
-        </p>
-      </div>
-      <Suspense
+    <Suspense
+      fallback={
+        <div className="text-xs text-gray-500">Loading debug panel...</div>
+      }
+    >
+      <ErrorBoundary
         fallback={
-          <div className="p-4 text-xs text-gray-500">
-            Loading debug panel...
+          <div className="text-sm text-red-500">
+            Error rendering debug panel
           </div>
         }
       >
-        <ErrorBoundary
-          fallback={
-            <div className="text-sm text-red-500">
-              Error rendering debug panel
-            </div>
-          }
-        >
-          <div className="w-full max-w-full overflow-hidden">
-            <LazyDebugPanel />
-          </div>
-        </ErrorBoundary>
-      </Suspense>
-    </div>
+        <LazyDebugPanel />
+      </ErrorBoundary>
+    </Suspense>
   );
 };

--- a/src/components/notebook/sidebar-panels/HelpPanel.tsx
+++ b/src/components/notebook/sidebar-panels/HelpPanel.tsx
@@ -1,0 +1,80 @@
+import React from "react";
+import { GitCommitHash } from "@/components/notebook/GitCommitHash";
+import type { SidebarPanelProps } from "./types";
+
+// Icons
+import { Star, Bug, ExternalLink } from "lucide-react";
+
+export const HelpPanel: React.FC<SidebarPanelProps> = () => {
+  return (
+    <div className="space-y-6">
+      <div>
+        <h4 className="mb-3 text-sm font-medium text-gray-700">
+          Keyboard Shortcuts
+        </h4>
+        <div className="space-y-3 text-sm">
+          <div className="flex justify-between">
+            <span className="text-gray-600">Navigate cells</span>
+            <code className="rounded bg-gray-100 px-2 py-1 text-xs">↑↓</code>
+          </div>
+          <div className="flex justify-between">
+            <span className="text-gray-600">Run & next</span>
+            <code className="rounded bg-gray-100 px-2 py-1 text-xs">
+              Shift+Enter
+            </code>
+          </div>
+          <div className="flex justify-between">
+            <span className="text-gray-600">Run cell</span>
+            <code className="rounded bg-gray-100 px-2 py-1 text-xs">
+              Ctrl+Enter
+            </code>
+          </div>
+        </div>
+      </div>
+
+      <div className="border-t pt-4">
+        <h4 className="mb-3 text-sm font-medium text-gray-700">
+          Getting Started
+        </h4>
+        <p className="text-xs text-gray-500">
+          Pick a cell type above to start experimenting with real-time
+          collaborative computing.
+        </p>
+      </div>
+
+      <div className="border-t pt-4">
+        <h4 className="mb-3 text-sm font-medium text-gray-700">About Anode</h4>
+        <div className="space-y-3">
+          <div className="flex flex-col space-y-2">
+            <a
+              href="https://github.com/runtimed/anode"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-2 rounded px-2 py-1.5 text-xs hover:bg-gray-100"
+            >
+              <Star className="h-3 w-3" />
+              <span>Star us on GitHub</span>
+              <ExternalLink className="h-3 w-3 opacity-60" />
+            </a>
+            <a
+              href="https://github.com/runtimed/anode/issues"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-2 rounded px-2 py-1.5 text-xs hover:bg-gray-100"
+            >
+              <Bug className="h-3 w-3" />
+              <span>Report a bug</span>
+              <ExternalLink className="h-3 w-3 opacity-60" />
+            </a>
+          </div>
+          <div className="border-t pt-2">
+            <div className="flex items-center justify-between text-xs">
+              <span className="text-gray-600">Build:</span>
+              <GitCommitHash />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/notebook/sidebar-panels/MetadataPanel.tsx
+++ b/src/components/notebook/sidebar-panels/MetadataPanel.tsx
@@ -1,0 +1,300 @@
+import React, { useState } from "react";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { useTrpc } from "@/components/TrpcProvider";
+import { trpcQueryClient } from "@/lib/trpc-client";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { TagBadge } from "@/components/notebooks/TagBadge";
+import { TagColorPicker } from "@/components/notebooks/TagColorPicker";
+import type { TagColor } from "backend/trpc/types";
+import type { Tag } from "@/components/notebooks/types";
+import type { SidebarPanelProps } from "./types";
+
+// Icons
+import { Plus, Edit3, Check, X, Trash2 } from "lucide-react";
+
+export const MetadataPanel: React.FC<SidebarPanelProps> = ({
+  notebook,
+  onUpdate,
+}) => {
+  const [searchTerm, setSearchTerm] = useState("");
+  const [editingTagId, setEditingTagId] = useState<string | null>(null);
+  const [editingTagName, setEditingTagName] = useState("");
+  const [editingTagColor, setEditingTagColor] = useState<TagColor>("#000000");
+  const [isCreatingTag, setIsCreatingTag] = useState(false);
+
+  const trpc = useTrpc();
+
+  // Fetch all available tags
+  const { data: allTags = [] } = useQuery(trpc.tags.queryOptions());
+
+  // Mutations
+  const assignTagMutation = useMutation(
+    trpc.assignTagToNotebook.mutationOptions()
+  );
+  const removeTagMutation = useMutation(
+    trpc.removeTagFromNotebook.mutationOptions()
+  );
+  const createTagMutation = useMutation(trpc.createTag.mutationOptions());
+  const updateTagMutation = useMutation(trpc.updateTag.mutationOptions());
+  const deleteTagMutation = useMutation(trpc.deleteTag.mutationOptions());
+
+  const currentTagIds = new Set(notebook.tags?.map((t) => t.id) || []);
+
+  const filteredAvailableTags = allTags.filter(
+    (tag) =>
+      !currentTagIds.has(tag.id) &&
+      tag.name.toLowerCase().includes(searchTerm.toLowerCase())
+  );
+
+  const exactMatch = allTags.find(
+    (tag) => tag.name.toLowerCase() === searchTerm.toLowerCase()
+  );
+
+  const refreshQueries = async () => {
+    await Promise.all([
+      trpcQueryClient.invalidateQueries({
+        queryKey: trpc.notebooks.queryKey(),
+      }),
+      trpcQueryClient.invalidateQueries({ queryKey: trpc.tags.queryKey() }),
+    ]);
+    onUpdate();
+  };
+
+  const handleAddTag = async (tagId: string) => {
+    try {
+      await assignTagMutation.mutateAsync({ nbId: notebook.id, tagId });
+      await refreshQueries();
+    } catch (error) {
+      console.error("Failed to add tag:", error);
+    }
+  };
+
+  const handleRemoveTag = async (tagId: string) => {
+    try {
+      await removeTagMutation.mutateAsync({ nbId: notebook.id, tagId });
+      await refreshQueries();
+    } catch (error) {
+      console.error("Failed to remove tag:", error);
+    }
+  };
+
+  const handleCreateTag = async () => {
+    if (!searchTerm.trim()) return;
+
+    setIsCreatingTag(true);
+    try {
+      const newTag = await createTagMutation.mutateAsync({
+        name: searchTerm.trim(),
+        color: "#3b82f6" as TagColor,
+      });
+
+      if (newTag) {
+        await assignTagMutation.mutateAsync({
+          nbId: notebook.id,
+          tagId: newTag.id,
+        });
+        setSearchTerm("");
+        await refreshQueries();
+      }
+    } catch (error) {
+      console.error("Failed to create tag:", error);
+    } finally {
+      setIsCreatingTag(false);
+    }
+  };
+
+  const startEditingTag = (tag: Tag) => {
+    setEditingTagId(tag.id);
+    setEditingTagName(tag.name);
+    setEditingTagColor(tag.color);
+  };
+
+  const cancelEditingTag = () => {
+    setEditingTagId(null);
+    setEditingTagName("");
+    setEditingTagColor("#000000");
+  };
+
+  const saveTagEdit = async () => {
+    if (!editingTagId || !editingTagName.trim()) return;
+
+    try {
+      await updateTagMutation.mutateAsync({
+        id: editingTagId,
+        name: editingTagName.trim(),
+        color: editingTagColor,
+      });
+
+      setEditingTagId(null);
+      await refreshQueries();
+    } catch (error) {
+      console.error("Failed to update tag:", error);
+    }
+  };
+
+  const handleDeleteTag = async (tagId: string) => {
+    if (
+      !confirm(
+        "Are you sure you want to delete this tag? It will be removed from all notebooks."
+      )
+    ) {
+      return;
+    }
+
+    try {
+      await deleteTagMutation.mutateAsync({ id: tagId });
+      await refreshQueries();
+    } catch (error) {
+      console.error("Failed to delete tag:", error);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      {/* Current Tags */}
+      <div>
+        <div className="mb-3 flex flex-wrap gap-2">
+          {notebook.tags?.length ? (
+            notebook.tags.map((tag) => (
+              <div key={tag.id} className="group relative">
+                {editingTagId === tag.id ? (
+                  <div className="space-y-2 rounded-lg border bg-gray-50 p-2">
+                    <Input
+                      value={editingTagName}
+                      onChange={(e) => setEditingTagName(e.target.value)}
+                      className="h-7 text-xs"
+                      placeholder="Tag name"
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter") {
+                          saveTagEdit();
+                        } else if (e.key === "Escape") {
+                          cancelEditingTag();
+                        }
+                      }}
+                      autoFocus
+                    />
+                    <TagColorPicker
+                      tagName={editingTagName}
+                      selectedColor={editingTagColor}
+                      onColorChange={setEditingTagColor}
+                    />
+                    <div className="flex gap-1">
+                      <Button
+                        size="sm"
+                        onClick={saveTagEdit}
+                        disabled={!editingTagName.trim()}
+                        className="h-6 px-2 text-xs"
+                      >
+                        <Check className="h-3 w-3" />
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        onClick={cancelEditingTag}
+                        className="h-6 px-2 text-xs"
+                      >
+                        <X className="h-3 w-3" />
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        onClick={() => handleDeleteTag(tag.id)}
+                        className="h-6 px-2 text-xs text-red-600 hover:text-red-700"
+                      >
+                        <Trash2 className="h-3 w-3" />
+                      </Button>
+                    </div>
+                  </div>
+                ) : (
+                  <div className="flex items-center gap-1">
+                    <button
+                      onClick={() => startEditingTag(tag)}
+                      className="rounded transition-opacity hover:opacity-80"
+                    >
+                      <TagBadge tag={tag} />
+                    </button>
+                    <div className="flex opacity-0 transition-opacity group-hover:opacity-100">
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        onClick={() => startEditingTag(tag)}
+                        className="h-5 w-5 p-0 text-gray-400 hover:text-gray-600"
+                      >
+                        <Edit3 className="h-3 w-3" />
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        onClick={() => handleRemoveTag(tag.id)}
+                        className="h-5 w-5 p-0 text-gray-400 hover:text-red-600"
+                      >
+                        <X className="h-3 w-3" />
+                      </Button>
+                    </div>
+                  </div>
+                )}
+              </div>
+            ))
+          ) : (
+            <span className="text-sm text-gray-500">No tags assigned</span>
+          )}
+        </div>
+      </div>
+
+      {/* Add Tags Section */}
+      <div className="border-t pt-4">
+        <h4 className="mb-3 text-sm font-medium text-gray-700">Add Tags</h4>
+
+        <Input
+          placeholder="Search or create tags..."
+          value={searchTerm}
+          onChange={(e) => setSearchTerm(e.target.value)}
+          className="mb-3"
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && searchTerm && !exactMatch) {
+              handleCreateTag();
+            }
+          }}
+        />
+
+        <div className="max-h-48 space-y-1 overflow-y-auto">
+          {/* Create new tag option */}
+          {searchTerm && !exactMatch && (
+            <button
+              onClick={handleCreateTag}
+              disabled={isCreatingTag}
+              className="flex w-full items-center gap-2 rounded p-2 text-left text-sm hover:bg-gray-50 disabled:opacity-50"
+            >
+              <Plus className="h-4 w-4 text-gray-500" />
+              <span>Create "{searchTerm}"</span>
+            </button>
+          )}
+
+          {/* Available tags */}
+          {filteredAvailableTags.slice(0, 10).map((tag) => (
+            <button
+              key={tag.id}
+              onClick={() => handleAddTag(tag.id)}
+              className="flex w-full items-center gap-2 rounded p-2 text-left text-sm hover:bg-gray-50"
+            >
+              <TagBadge tag={tag} className="text-xs" />
+            </button>
+          ))}
+
+          {filteredAvailableTags.length === 0 && !searchTerm && (
+            <div className="py-2 text-center text-sm text-gray-500">
+              All available tags are already assigned
+            </div>
+          )}
+
+          {filteredAvailableTags.length === 0 && searchTerm && exactMatch && (
+            <div className="py-2 text-center text-sm text-gray-500">
+              Tag already exists
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/notebook/sidebar-panels/MetadataPanel.tsx
+++ b/src/components/notebook/sidebar-panels/MetadataPanel.tsx
@@ -109,14 +109,15 @@ export const MetadataPanel: React.FC<SidebarPanelProps> = ({
     }
   };
 
-  const handleCreateTag = async () => {
+  const handleCreateTag = async (color?: TagColor) => {
     if (!searchTerm.trim()) return;
 
+    const tagColor = color || previewColor;
     setIsCreatingTag(true);
     try {
       const newTag = await createTagMutation.mutateAsync({
         name: searchTerm.trim(),
-        color: previewColor,
+        color: tagColor,
       });
 
       if (newTag) {
@@ -288,51 +289,41 @@ export const MetadataPanel: React.FC<SidebarPanelProps> = ({
           }}
         />
 
-        {/* Preview and quick colors for new tag */}
-        {searchTerm && !exactMatch && (
-          <div className="mb-3 space-y-2 rounded-lg border bg-gray-50 p-3">
-            <div className="flex items-center justify-between">
-              <span className="text-xs font-medium text-gray-700">
-                Preview:
-              </span>
-              <TagBadge
-                tag={{
-                  id: "preview",
-                  name: searchTerm,
-                  color: previewColor,
-                }}
-                className="text-xs"
-              />
-            </div>
-            <div className="flex flex-wrap gap-1">
-              {TAG_COLOR_PALETTE.slice(0, 8).map((color) => (
-                <button
-                  key={color}
-                  onClick={() => setPreviewColor(color)}
-                  className={`h-6 w-6 rounded border-2 ${
-                    previewColor === color
-                      ? "border-gray-400"
-                      : "border-gray-200"
-                  }`}
-                  style={{ backgroundColor: color }}
-                  title={`Use ${color}`}
-                />
-              ))}
-            </div>
-          </div>
-        )}
-
         <div className="max-h-48 space-y-1 overflow-y-auto">
           {/* Create new tag option */}
           {searchTerm && !exactMatch && (
-            <button
-              onClick={handleCreateTag}
-              disabled={isCreatingTag}
-              className="flex w-full items-center gap-2 rounded p-2 text-left text-sm hover:bg-gray-50 disabled:opacity-50"
-            >
-              <Plus className="h-4 w-4 text-gray-500" />
-              <span>Create "{searchTerm}"</span>
-            </button>
+            <div className="rounded-lg border bg-gray-50 p-3">
+              <div className="mb-2 flex items-center justify-between">
+                <button
+                  onClick={() => handleCreateTag()}
+                  disabled={isCreatingTag}
+                  className="flex items-center gap-2 rounded px-2 py-1 text-sm hover:bg-gray-100 disabled:opacity-50"
+                >
+                  <Plus className="h-4 w-4 text-gray-500" />
+                  <span>Create "{searchTerm}"</span>
+                </button>
+                <TagBadge
+                  tag={{
+                    id: "preview",
+                    name: searchTerm,
+                    color: previewColor,
+                  }}
+                  className="text-xs"
+                />
+              </div>
+              <div className="flex flex-wrap gap-1">
+                {TAG_COLOR_PALETTE.slice(0, 8).map((color) => (
+                  <button
+                    key={color}
+                    onClick={() => handleCreateTag(color)}
+                    disabled={isCreatingTag}
+                    className="h-6 w-6 rounded border-2 border-gray-200 hover:border-gray-400 disabled:opacity-50"
+                    style={{ backgroundColor: color }}
+                    title={`Create "${searchTerm}" with ${color}`}
+                  />
+                ))}
+              </div>
+            </div>
           )}
 
           {/* Available tags */}

--- a/src/components/notebook/sidebar-panels/MetadataPanel.tsx
+++ b/src/components/notebook/sidebar-panels/MetadataPanel.tsx
@@ -44,14 +44,17 @@ export const MetadataPanel: React.FC<SidebarPanelProps> = ({
   const [editingTagName, setEditingTagName] = useState("");
   const [editingTagColor, setEditingTagColor] = useState<TagColor>("#000000");
   const [isCreatingTag, setIsCreatingTag] = useState(false);
+  const [selectedColor, setSelectedColor] = useState<TagColor>("#3b82f6");
   const [previewColor, setPreviewColor] = useState<TagColor>("#3b82f6");
 
   const trpc = useTrpc();
 
-  // Update preview color when search term changes
+  // Update colors when search term changes
   useEffect(() => {
     if (searchTerm) {
-      setPreviewColor(getRandomTagColor());
+      const randomColor = getRandomTagColor();
+      setSelectedColor(randomColor);
+      setPreviewColor(randomColor);
     }
   }, [searchTerm]);
 
@@ -109,15 +112,14 @@ export const MetadataPanel: React.FC<SidebarPanelProps> = ({
     }
   };
 
-  const handleCreateTag = async (color?: TagColor) => {
+  const handleCreateTag = async () => {
     if (!searchTerm.trim()) return;
 
-    const tagColor = color || previewColor;
     setIsCreatingTag(true);
     try {
       const newTag = await createTagMutation.mutateAsync({
         name: searchTerm.trim(),
-        color: tagColor,
+        color: selectedColor,
       });
 
       if (newTag) {
@@ -315,11 +317,20 @@ export const MetadataPanel: React.FC<SidebarPanelProps> = ({
                 {TAG_COLOR_PALETTE.slice(0, 8).map((color) => (
                   <button
                     key={color}
-                    onClick={() => handleCreateTag(color)}
+                    onClick={() => {
+                      setSelectedColor(color);
+                      setPreviewColor(color);
+                    }}
+                    onMouseEnter={() => setPreviewColor(color)}
+                    onMouseLeave={() => setPreviewColor(selectedColor)}
                     disabled={isCreatingTag}
-                    className="h-6 w-6 rounded border-2 border-gray-200 hover:border-gray-400 disabled:opacity-50"
+                    className={`h-6 w-6 rounded border-2 hover:border-gray-400 disabled:opacity-50 ${
+                      selectedColor === color
+                        ? "border-gray-600"
+                        : "border-gray-200"
+                    }`}
                     style={{ backgroundColor: color }}
-                    title={`Create "${searchTerm}" with ${color}`}
+                    title={`Select ${color}`}
                   />
                 ))}
               </div>

--- a/src/components/notebook/sidebar-panels/RuntimePanel.tsx
+++ b/src/components/notebook/sidebar-panels/RuntimePanel.tsx
@@ -1,0 +1,80 @@
+import React from "react";
+import { RuntimeHealthIndicator } from "@/components/notebook/RuntimeHealthIndicator";
+import { useRuntimeHealth } from "@/hooks/useRuntimeHealth";
+import type { SidebarPanelProps } from "./types";
+
+export const RuntimePanel: React.FC<SidebarPanelProps> = () => {
+  const { hasActiveRuntime, activeRuntime } = useRuntimeHealth();
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h4 className="mb-3 text-sm font-medium text-gray-700">
+          Runtime Status
+        </h4>
+        <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <span className="text-xs text-gray-600">Connection</span>
+            <RuntimeHealthIndicator showStatus />
+          </div>
+          {hasActiveRuntime && (
+            <div className="flex items-center justify-between">
+              <span className="text-xs text-gray-600">Type</span>
+              <span className="font-mono text-xs">
+                {activeRuntime?.runtimeType ?? "unknown"}
+              </span>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {hasActiveRuntime && activeRuntime && (
+        <div className="border-t pt-4">
+          <h4 className="mb-2 text-xs font-medium text-gray-700">
+            Runtime Details
+          </h4>
+          <div className="space-y-1 text-xs">
+            <div className="flex justify-between">
+              <span className="text-gray-600">Session:</span>
+              <code className="rounded bg-gray-100 px-1 text-xs">
+                {activeRuntime.sessionId.slice(-8)}
+              </code>
+            </div>
+            <div className="flex justify-between">
+              <span className="text-gray-600">Status:</span>
+              <span
+                className={`text-xs font-medium ${
+                  activeRuntime.status === "ready"
+                    ? "text-green-600"
+                    : activeRuntime.status === "busy"
+                      ? "text-amber-600"
+                      : "text-red-600"
+                }`}
+              >
+                {activeRuntime.status === "ready"
+                  ? "Ready"
+                  : activeRuntime.status === "busy"
+                    ? "Busy"
+                    : activeRuntime.status.charAt(0).toUpperCase() +
+                      activeRuntime.status.slice(1)}
+              </span>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {!hasActiveRuntime && (
+        <div className="border-t pt-4">
+          <div className="space-y-2">
+            <p className="text-xs text-gray-500">
+              Start a runtime to execute code cells.
+            </p>
+            <p className="text-xs text-gray-500">
+              Setup instructions will be available here.
+            </p>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/notebook/sidebar-panels/config.ts
+++ b/src/components/notebook/sidebar-panels/config.ts
@@ -1,0 +1,92 @@
+import type { SidebarItemConfig, SidebarSection } from "./types";
+import {
+  Tag,
+  ListChecks,
+  MonitorCheck,
+  MonitorOff,
+  DatabaseZap,
+  HelpCircle,
+} from "lucide-react";
+
+interface SidebarConfigOptions {
+  hasActiveRuntime: boolean;
+  runtimeHealth: string;
+  activeSection: SidebarSection | null;
+  isDev: boolean;
+}
+
+const SIDEBAR_ITEM_CONFIGS: Record<SidebarSection, SidebarItemConfig> = {
+  metadata: {
+    id: "metadata",
+    icon: Tag,
+    tooltip: "Tags & Metadata",
+    title: "Tags",
+  },
+  runtime: {
+    id: "runtime",
+    icon: MonitorCheck, // Will be overridden based on runtime state
+    tooltip: "Runtime",
+    title: "Runtime Configuration",
+  },
+  ai: {
+    id: "ai",
+    icon: ListChecks,
+    tooltip: "AI Context Controls",
+    title: "AI Context Controls",
+  },
+  debug: {
+    id: "debug",
+    icon: DatabaseZap,
+    tooltip: "LiveStore Debug",
+    title: "Debug Panel",
+  },
+  help: {
+    id: "help",
+    icon: HelpCircle,
+    tooltip: "Help & Shortcuts",
+    title: "Help & Keyboard Shortcuts",
+  },
+};
+
+export function getSidebarItems(
+  options: SidebarConfigOptions
+): SidebarItemConfig[] {
+  const { hasActiveRuntime, runtimeHealth, activeSection, isDev } = options;
+
+  const items: SidebarItemConfig[] = [];
+
+  // Always show metadata panel
+  items.push(SIDEBAR_ITEM_CONFIGS.metadata);
+
+  // Show runtime panel conditionally
+  const shouldShowRuntime =
+    hasActiveRuntime ||
+    runtimeHealth !== "healthy" ||
+    activeSection === "runtime";
+
+  if (shouldShowRuntime) {
+    items.push({
+      ...SIDEBAR_ITEM_CONFIGS.runtime,
+      icon: hasActiveRuntime ? MonitorCheck : MonitorOff,
+    });
+  }
+
+  // Always show AI panel
+  items.push(SIDEBAR_ITEM_CONFIGS.ai);
+
+  // Show debug panel only in development
+  if (isDev) {
+    items.push(SIDEBAR_ITEM_CONFIGS.debug);
+  }
+
+  // Always show help panel
+  items.push(SIDEBAR_ITEM_CONFIGS.help);
+
+  return items;
+}
+
+export function getSidebarItemConfig(
+  section: SidebarSection
+): SidebarItemConfig {
+  return SIDEBAR_ITEM_CONFIGS[section];
+}

--- a/src/components/notebook/sidebar-panels/index.ts
+++ b/src/components/notebook/sidebar-panels/index.ts
@@ -1,0 +1,12 @@
+export { MetadataPanel } from "./MetadataPanel";
+export { AiPanel } from "./AiPanel";
+export { RuntimePanel } from "./RuntimePanel";
+export { HelpPanel } from "./HelpPanel";
+export { DebugPanel } from "./DebugPanel";
+
+export type {
+  SidebarPanelProps,
+  SidebarSection,
+  SidebarItemConfig,
+  SidebarPanelComponent,
+} from "./types";

--- a/src/components/notebook/sidebar-panels/types.ts
+++ b/src/components/notebook/sidebar-panels/types.ts
@@ -1,0 +1,19 @@
+import type { NotebookProcessed } from "@/components/notebooks/types";
+
+export interface SidebarPanelProps {
+  notebook: NotebookProcessed;
+  onUpdate: () => void;
+}
+
+export type SidebarSection = "metadata" | "ai" | "runtime" | "debug" | "help";
+
+export interface SidebarItemConfig {
+  id: SidebarSection;
+  icon: React.ComponentType<{ className?: string }>;
+  tooltip: string;
+  title: string;
+}
+
+export interface SidebarPanelComponent extends React.FC<SidebarPanelProps> {
+  displayName?: string;
+}

--- a/src/components/notebooks/TagBadge.tsx
+++ b/src/components/notebooks/TagBadge.tsx
@@ -9,15 +9,22 @@ interface TagBadgeProps {
 }
 
 // Function to determine if text should be white or black based on background color
-// Uses chroma-js for proper WCAG contrast calculation
+// Biased toward white text for better readability on medium-dark colors, especially blues
 function getContrastTextColor(hexColor: string): string {
   const color = chroma(hexColor);
 
-  // Calculate contrast with white and black, return the one with better contrast
-  const contrastWithWhite = chroma.contrast(color, "white");
-  const contrastWithBlack = chroma.contrast(color, "black");
+  // Get HSL values to check for blue hues and lightness
+  const [hue, , lightness] = color.hsl();
 
-  return contrastWithWhite > contrastWithBlack ? "#ffffff" : "#000000";
+  // For blue-ish colors (210-270 degrees), use white text unless very light
+  const isBlueish = hue >= 210 && hue <= 270;
+  if (isBlueish && lightness < 0.8) {
+    return "#ffffff";
+  }
+
+  // For other colors, use white text if lightness is below 0.65 (biased toward white)
+  // This is more conservative than pure contrast calculation
+  return lightness < 0.65 ? "#ffffff" : "#000000";
 }
 
 export const TagBadge: React.FC<TagBadgeProps> = ({ tag, className = "" }) => {


### PR DESCRIPTION
- Create separate component files for each sidebar panel (metadata, ai, runtime, debug, help)
- Add consistent SidebarPanelProps interface and configuration system
- Implement inline tag editing in MetadataPanel with hover controls
- Remove modal-based tag editing in favor of direct panel editing
- Clean up redundant titles (now just 'Tags' instead of 'Tags & Metadata' + 'Current Tags')


<img width="305" height="366" alt="image" src="https://github.com/user-attachments/assets/efecfeb7-89bb-40a5-ab79-7889a66ac5d1" />
