### PR TITLE
Update pm2 setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -304,7 +304,7 @@ const titleMetadata = useQuery(
 │   ├── deploy-iframe-outputs.sh
 │   ├── dev-runtime.sh
 │   ├── optimize-build.sh
-│   ├── start-nb.sh
+│   ├── open-browser.sh
 │   ├── start-runt-dev.sh
 │   ├── test-api-key-flow.sh
 │   ├── test-api-keys.sh

--- a/PM2-SETUP.md
+++ b/PM2-SETUP.md
@@ -67,19 +67,10 @@ pm2 delete all
 
 ### Process Names
 
+- `iframe-outputs`: Runs `pnpm run dev:iframe` (for displaying outputs in an iframe)
 - `web`: Runs `pnpm run dev` (Vite development server with integrated Cloudflare Workers on port 5173)
 - `sync`: Runs `pnpm run dev:sync` (Cloudflare Worker backend on port 8787)
-- `nb`: Runs `./scripts/start-nb.sh` (Deno runtime agent with unique notebook ID)
 - `watcher`: Monitors the schema file and triggers updates
-
-### Runtime Process Details
-
-The `nb` process runs `scripts/start-nb.sh` which:
-
-- Sets `DEV_PORT=5173`
-- Generates a unique notebook ID using timestamp and random hex
-- Opens a browser tab to `http://localhost:5173/?notebook=$NOTEBOOK_ID`
-- Starts the Deno runtime agent with debug logging
 
 ### Architecture Options
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "pnpm": ">=10.9.0"
   },
   "scripts": {
-    "dev:runt": "./scripts/start-runt-dev.sh",
+    "dev:pm2": "./scripts/start-runt-dev.sh",
     "dev": "vite",
     "dev:web": "vite --no-open",
     "dev:iframe": "cd iframe-outputs && vite --port 8000",

--- a/scripts/open-browser.sh
+++ b/scripts/open-browser.sh
@@ -7,30 +7,21 @@ fi
 # 🚨 IMPORTANT: We're overriding the runtime command here to avoid it breaking by accident
 export VITE_RUNTIME_COMMAND="deno run --allow-all --unstable-broadcast-channel --env-file=../anode/.env ../runt/packages/pyodide-runtime-agent/src/mod.ts"
 export DEV_PORT=${ANODE_DEV_SERVER_PORT:-5173}
-export NOTEBOOK_ID=$(date +%s)-$(openssl rand -hex 4)
+export NOTEBOOK_ID=$(openssl rand -hex 8)
 
-URL="http://localhost:$DEV_PORT/?notebook=$NOTEBOOK_ID"
+URL="http://localhost:$DEV_PORT"
 
 echo "ANODE_OPEN_INCOGNITO: $ANODE_OPEN_INCOGNITO"
 
-RUNTIME_CMD="NOTEBOOK_ID=${NOTEBOOK_ID} ${VITE_RUNTIME_COMMAND}"
-
 echo ""
 echo "=============================================="
 echo "✨✨✨✨✨✨✨✨✨✨✨✨✨✨✨✨✨✨✨✨✨✨✨✨✨✨✨✨"
 echo ""
-echo "🔗 Notebook URL: $URL"
-echo ""
-echo "🐇 Runtime command (started in background):"
-echo ""
-echo "$RUNTIME_CMD"
+echo "🔗 Anode URL: $URL"
 echo ""
 echo "✨✨✨✨✨✨✨✨✨✨✨✨✨✨✨✨✨✨✨✨✨✨✨✨✨✨✨✨"
 echo "=============================================="
 echo ""
-
-# Start runtime in background
-pnpm exec pm2 start --name "notebook=$NOTEBOOK_ID" "$RUNTIME_CMD"
 
 sleep 1
 

--- a/scripts/start-runt-dev.sh
+++ b/scripts/start-runt-dev.sh
@@ -21,7 +21,7 @@ echo ""
 echo "📊 PM2 Status:"
 pnpm exec pm2 status
 
-./scripts/start-nb.sh
+./scripts/open-browser.sh
 
 echo "🚀 Started runtime!"
 


### PR DESCRIPTION
The current setup doesn't properly start notebooks anymore, so removing that for now, and updating a couple other things

- Don't start a nb by default
- Rename command from `dev:runt` to `dev:pm2`
- Add `iframe-outputs` to list of process names