### PR TITLE
Jsr from anode

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,101 @@
+name: Publish Schema Package
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  id-token: write # Required for npm provenance and JSR OIDC
+  contents: read
+
+jobs:
+  validate-and-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "23"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install JSR CLI
+        run: npm install -g jsr
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Validate version consistency
+        run: |
+          PACKAGE_VERSION=$(node -p "require('./packages/schema/package.json').version")
+          JSR_VERSION=$(node -p "require('./packages/schema/jsr.json').version")
+
+          echo "package.json version: $PACKAGE_VERSION"
+          echo "jsr.json version: $JSR_VERSION"
+
+          if [ "$PACKAGE_VERSION" != "$JSR_VERSION" ]; then
+            echo "❌ Version mismatch: package.json ($PACKAGE_VERSION) != jsr.json ($JSR_VERSION)"
+            exit 1
+          fi
+
+          echo "✅ Versions match: $PACKAGE_VERSION"
+
+      - name: Extract tag version
+        id: tag_version
+        run: |
+          TAG_VERSION=${GITHUB_REF#refs/tags/v}
+          echo "tag_version=$TAG_VERSION" >> $GITHUB_OUTPUT
+          echo "Tag version: $TAG_VERSION"
+
+      - name: Validate tag matches package version
+        run: |
+          PACKAGE_VERSION=$(node -p "require('./packages/schema/package.json').version")
+          TAG_VERSION="${{ steps.tag_version.outputs.tag_version }}"
+
+          if [ "$PACKAGE_VERSION" != "$TAG_VERSION" ]; then
+            echo "❌ Tag version ($TAG_VERSION) doesn't match package version ($PACKAGE_VERSION)"
+            exit 1
+          fi
+
+          echo "✅ Tag version matches package version: $TAG_VERSION"
+
+      - name: Run type check
+        run: pnpm --filter schema type-check
+
+      - name: Run lint check
+        run: pnpm --filter schema lint:check
+
+      - name: Run format check
+        run: pnpm --filter schema format:check
+
+      - name: Test JSR publish (dry run)
+        run: pnpm --filter schema exec jsr publish --dry-run --allow-slow-types --allow-dirty
+
+      - name: Publish to npm
+        run: pnpm --filter schema publish --access public --no-git-checks
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish to JSR
+        run: pnpm --filter schema exec jsr publish --allow-slow-types
+        env:
+          JSR_TOKEN: ${{ secrets.JSR_TOKEN }}
+
+      - name: Create GitHub Release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Schema v${{ steps.tag_version.outputs.tag_version }}
+          body: |
+            Published @runtimed/schema v${{ steps.tag_version.outputs.tag_version }} to:
+            - npm: https://www.npmjs.com/package/@runtimed/schema
+            - JSR: https://jsr.io/@runtimed/schema
+          draft: false
+          prerelease: false

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -77,14 +77,10 @@ jobs:
         run: pnpm --filter schema exec jsr publish --dry-run --allow-slow-types --allow-dirty
 
       - name: Publish to npm
-        run: pnpm --filter schema publish --access public --no-git-checks
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: pnpm --filter schema publish --access public --no-git-checks --provenance
 
       - name: Publish to JSR
         run: pnpm --filter schema exec jsr publish --allow-slow-types
-        env:
-          JSR_TOKEN: ${{ secrets.JSR_TOKEN }}
 
       - name: Create GitHub Release
         uses: actions/create-release@v1

--- a/backend/sync.ts
+++ b/backend/sync.ts
@@ -5,7 +5,7 @@ import {
 import { type Env, type ExecutionContext } from "./types";
 
 import { getValidatedUser } from "./auth";
-import { Schema } from "@livestore/livestore";
+import { Schema } from "@runtimed/schema";
 
 export class WebSocketServer extends makeDurableObject({
   onPush: async (message) => {

--- a/docs/schema-publishing.md
+++ b/docs/schema-publishing.md
@@ -1,0 +1,215 @@
+# Schema Package Publishing
+
+This document explains how to publish the `@runtimed/schema` package to both npm and JSR.
+
+## Overview
+
+The `@runtimed/schema` package is published to two registries:
+- **npm**: https://www.npmjs.com/package/@runtimed/schema
+- **JSR**: https://jsr.io/@runtimed/schema
+
+Both registries are kept in sync with matching version numbers.
+
+## Prerequisites
+
+### For Automated Publishing (GitHub Actions)
+
+1. **NPM_TOKEN**: npm access token with publish permissions
+   - Generate at: https://www.npmjs.com/settings/tokens
+   - Add to GitHub repository secrets
+
+2. **JSR_TOKEN**: JSR access token with publish permissions
+   - Generate at: https://jsr.io/account/tokens
+   - Add to GitHub repository secrets
+
+### For Manual Publishing
+
+1. **npm**: Authenticated with `npm login`
+2. **JSR**: JSR CLI installed (`npm install -g jsr`)
+
+## Automated Publishing (Recommended)
+
+Publishing is automated via GitHub Actions when you push a git tag:
+
+### 1. Update Version
+
+Use the provided script to update both `package.json` and `jsr.json`:
+
+```bash
+# Bump to a new version (e.g., 0.1.3)
+pnpm bump-schema 0.1.3
+```
+
+This script:
+- Updates version in both `package.json` and `jsr.json`
+- Validates version format
+- Stages changes for git commit
+
+### 2. Test Locally
+
+Before publishing, test that everything works:
+
+```bash
+pnpm test-publish
+```
+
+This runs:
+- Version consistency check
+- Type checking
+- Linting
+- Format checking
+- Dry run publishing to both registries
+
+### 3. Commit and Tag
+
+```bash
+git commit -m "Bump schema version to v0.1.3"
+git tag v0.1.3
+git push origin HEAD --tags
+```
+
+### 4. GitHub Actions Takes Over
+
+The workflow (`.github/workflows/publish.yml`) automatically:
+1. Validates version consistency
+2. Runs all checks (type, lint, format)
+3. Tests dry run publishing
+4. Publishes to npm
+5. Publishes to JSR
+6. Creates GitHub release
+
+## Manual Publishing
+
+If you need to publish manually:
+
+### 1. Prepare and Test
+
+```bash
+# Update versions
+pnpm bump-schema 0.1.3
+
+# Test everything
+pnpm test-publish
+```
+
+### 2. Publish to npm
+
+```bash
+pnpm --filter schema publish --access public --no-git-checks
+```
+
+### 3. Publish to JSR
+
+```bash
+pnpm --filter schema exec jsr publish --allow-slow-types
+```
+
+## Workflow Details
+
+### Version Management
+
+- Both `package.json` and `jsr.json` must have matching version numbers
+- Use semantic versioning (e.g., `0.1.3`, `1.0.0`, `2.1.0-beta.1`)
+- The `bump-schema` script ensures consistency
+
+### Validation Steps
+
+The publishing process includes several validation steps:
+
+1. **Version Consistency**: Both files have matching versions
+2. **Tag Validation**: Git tag matches package version
+3. **Type Check**: TypeScript compilation without errors
+4. **Lint Check**: ESLint passes with no warnings
+5. **Format Check**: Prettier formatting is correct
+6. **Publish Dry Run**: Both registries accept the package
+
+### Publishing Strategy
+
+- **Tags trigger publishing**: Only git tags starting with `v` trigger the workflow
+- **Both registries**: Package is published to npm and JSR simultaneously
+- **Failure handling**: If either registry fails, the workflow stops
+- **GitHub Release**: Automatically created with links to both registries
+
+## Troubleshooting
+
+### Version Mismatch
+
+```bash
+❌ Version mismatch: package.json (0.1.2) != jsr.json (0.1.1)
+```
+
+**Solution**: Use `pnpm bump-schema <version>` to sync versions.
+
+### JSR Slow Types Warning
+
+```
+Warning Publishing a library with slow types is not recommended.
+```
+
+This is expected. The schema package uses complex TypeScript types that JSR considers "slow types". We use `--allow-slow-types` to publish anyway.
+
+### npm Authentication
+
+```bash
+npm error code ENEEDAUTH
+```
+
+**Solution**: Run `npm login` or ensure `NPM_TOKEN` is set correctly.
+
+### JSR Authentication
+
+```bash
+error: Unauthorized
+```
+
+**Solution**: Ensure `JSR_TOKEN` is set correctly in GitHub secrets or run `jsr auth` for manual publishing.
+
+### Git Tag Issues
+
+```bash
+❌ Tag version (0.1.3) doesn't match package version (0.1.2)
+```
+
+**Solution**: Ensure you've committed the version bump before tagging, or update the tag to match the package version.
+
+## Scripts Reference
+
+| Script | Command | Purpose |
+|--------|---------|---------|
+| Version Bump | `pnpm bump-schema <version>` | Update package versions consistently |
+| Test Publish | `pnpm test-publish` | Validate everything before publishing |
+| Manual npm | `pnpm --filter schema publish --access public` | Publish to npm only |
+| Manual JSR | `pnpm --filter schema exec jsr publish --allow-slow-types` | Publish to JSR only |
+
+## Package Structure
+
+```
+packages/schema/
+├── package.json      # npm package configuration
+├── jsr.json         # JSR package configuration  
+├── README.md        # Package documentation
+├── src/
+│   ├── index.ts     # Main export
+│   ├── tables.ts    # Database schema
+│   ├── types.ts     # TypeScript types
+│   └── queries/     # Query helpers
+└── tsconfig.json    # TypeScript configuration
+```
+
+## Release Checklist
+
+- [ ] Version numbers match in `package.json` and `jsr.json`
+- [ ] `pnpm test-publish` passes all checks
+- [ ] Changes committed to git
+- [ ] Git tag created and pushed
+- [ ] GitHub Actions workflow completes successfully
+- [ ] Both npm and JSR packages are live
+- [ ] GitHub release is created
+
+## Support
+
+For issues with the publishing process:
+1. Check GitHub Actions logs for detailed error messages
+2. Test locally with `pnpm test-publish`
+3. Verify authentication tokens are valid
+4. Ensure version numbers are consistent

--- a/docs/schema-publishing.md
+++ b/docs/schema-publishing.md
@@ -5,6 +5,7 @@ This document explains how to publish the `@runtimed/schema` package to both npm
 ## Overview
 
 The `@runtimed/schema` package is published to two registries:
+
 - **npm**: https://www.npmjs.com/package/@runtimed/schema
 - **JSR**: https://jsr.io/@runtimed/schema
 
@@ -41,6 +42,7 @@ pnpm bump-schema 0.1.3
 ```
 
 This script:
+
 - Updates version in both `package.json` and `jsr.json`
 - Validates version format
 - Stages changes for git commit
@@ -54,6 +56,7 @@ pnpm test-publish
 ```
 
 This runs:
+
 - Version consistency check
 - Type checking
 - Linting
@@ -71,6 +74,7 @@ git push origin HEAD --tags
 ### 4. GitHub Actions Takes Over
 
 The workflow (`.github/workflows/publish.yml`) automatically:
+
 1. Validates version consistency
 2. Runs all checks (type, lint, format)
 3. Tests dry run publishing
@@ -174,19 +178,19 @@ error: Unauthorized
 
 ## Scripts Reference
 
-| Script | Command | Purpose |
-|--------|---------|---------|
-| Version Bump | `pnpm bump-schema <version>` | Update package versions consistently |
-| Test Publish | `pnpm test-publish` | Validate everything before publishing |
-| Manual npm | `pnpm --filter schema publish --access public` | Publish to npm only |
-| Manual JSR | `pnpm --filter schema exec jsr publish --allow-slow-types` | Publish to JSR only |
+| Script       | Command                                                    | Purpose                               |
+| ------------ | ---------------------------------------------------------- | ------------------------------------- |
+| Version Bump | `pnpm bump-schema <version>`                               | Update package versions consistently  |
+| Test Publish | `pnpm test-publish`                                        | Validate everything before publishing |
+| Manual npm   | `pnpm --filter schema publish --access public`             | Publish to npm only                   |
+| Manual JSR   | `pnpm --filter schema exec jsr publish --allow-slow-types` | Publish to JSR only                   |
 
 ## Package Structure
 
 ```
 packages/schema/
 ├── package.json      # npm package configuration
-├── jsr.json         # JSR package configuration  
+├── jsr.json         # JSR package configuration
 ├── README.md        # Package documentation
 ├── src/
 │   ├── index.ts     # Main export
@@ -209,6 +213,7 @@ packages/schema/
 ## Support
 
 For issues with the publishing process:
+
 1. Check GitHub Actions logs for detailed error messages
 2. Test locally with `pnpm test-publish`
 3. Verify authentication tokens are valid

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "dev:runtime": "./scripts/dev-runtime.sh",
     "build:iframe": "cd iframe-outputs && vite build",
     "build": "vite build --mode development",
+    "bump-schema": "./scripts/bump-schema-version.sh",
+    "test-publish": "./scripts/test-publish.sh",
     "build:preview": "vite build --mode preview",
     "build:production": "./scripts/optimize-build.sh && vite build --mode production",
     "build:production:fast": "vite build --mode production",

--- a/packages/schema/jsr.json
+++ b/packages/schema/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@runtimed/schema",
-  "version": "0.14.0",
+  "version": "0.1.0",
   "exports": "./src/index.ts",
   "license": "BSD-3-Clause"
 }

--- a/packages/schema/jsr.json
+++ b/packages/schema/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@runtimed/schema",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "exports": "./src/index.ts",
   "license": "BSD-3-Clause"
 }

--- a/packages/schema/jsr.json
+++ b/packages/schema/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@runtimed/schema",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "exports": "./src/index.ts",
   "license": "BSD-3-Clause"
 }

--- a/packages/schema/jsr.json
+++ b/packages/schema/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@runtimed/schema",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "exports": "./src/index.ts",
   "license": "BSD-3-Clause"
 }

--- a/packages/schema/jsr.json
+++ b/packages/schema/jsr.json
@@ -1,0 +1,6 @@
+{
+  "name": "@runtimed/schema",
+  "version": "0.14.0",
+  "exports": "./src/index.ts",
+  "license": "BSD-3-Clause"
+}

--- a/packages/schema/jsr.json
+++ b/packages/schema/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@runtimed/schema",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "exports": "./src/index.ts",
   "license": "BSD-3-Clause"
 }

--- a/packages/schema/jsr.json
+++ b/packages/schema/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@runtimed/schema",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "exports": "./src/index.ts",
   "license": "BSD-3-Clause"
 }

--- a/packages/schema/jsr.json
+++ b/packages/schema/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@runtimed/schema",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "exports": "./src/index.ts",
   "license": "BSD-3-Clause"
 }

--- a/packages/schema/jsr.json
+++ b/packages/schema/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@runtimed/schema",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "exports": "./src/index.ts",
   "license": "BSD-3-Clause"
 }

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@runtimed/schema",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "type": "module",
   "description": "Schema definitions for Anode - event-sourced notebook system",
   "exports": "./src/index.ts",

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@runtimed/schema",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "type": "module",
   "description": "Schema definitions for Anode - event-sourced notebook system",
   "exports": "./src/index.ts",

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@runtimed/schema",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "type": "module",
   "description": "Schema definitions for Anode - event-sourced notebook system",
   "exports": "./src/index.ts",

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@runtimed/schema",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "type": "module",
   "description": "Schema definitions for Anode - event-sourced notebook system",
   "exports": "./src/index.ts",

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@runtimed/schema",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "type": "module",
   "description": "Schema definitions for Anode - event-sourced notebook system",
   "exports": "./src/index.ts",

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@runtimed/schema",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "type": "module",
   "description": "Schema definitions for Anode - event-sourced notebook system",
   "exports": "./src/index.ts",

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -4,7 +4,25 @@ import {
   Events,
   Schema,
   Store as LiveStore,
+  queryDb,
+  SessionIdSymbol,
+  signal,
+  createStorePromise,
 } from "@livestore/livestore";
+
+export type { BootStatus } from "@livestore/livestore";
+
+export {
+  makeSchema,
+  State,
+  Events,
+  Schema,
+  LiveStore,
+  queryDb,
+  SessionIdSymbol,
+  signal,
+  createStorePromise,
+};
 
 export * as queries from "./queries/index.ts";
 

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -11,7 +11,7 @@ import {
   sql,
 } from "@livestore/livestore";
 
-export type { BootStatus } from "@livestore/livestore";
+export type { BootStatus, Adapter } from "@livestore/livestore";
 
 export {
   makeSchema,

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -8,6 +8,7 @@ import {
   SessionIdSymbol,
   signal,
   createStorePromise,
+  sql,
 } from "@livestore/livestore";
 
 export type { BootStatus } from "@livestore/livestore";
@@ -22,6 +23,7 @@ export {
   SessionIdSymbol,
   signal,
   createStorePromise,
+  sql,
 };
 
 export * as queries from "./queries/index.ts";

--- a/packages/schema/src/queries/cellOrdering.ts
+++ b/packages/schema/src/queries/cellOrdering.ts
@@ -1,5 +1,5 @@
 import { tables } from "../tables.ts";
-import { queryDb } from "@livestore/livestore";
+import { queryDb } from "@runtimed/schema";
 
 /**
  * Cell ordering queries using fractional indexing

--- a/packages/schema/src/queries/index.ts
+++ b/packages/schema/src/queries/index.ts
@@ -1,5 +1,5 @@
 import { tables } from "../tables.ts";
-import { queryDb } from "@livestore/livestore";
+import { queryDb } from "@runtimed/schema";
 
 export * from "./outputDeltas.ts";
 export * from "./cellOrdering.ts";

--- a/packages/schema/src/queries/outputDeltas.ts
+++ b/packages/schema/src/queries/outputDeltas.ts
@@ -1,5 +1,5 @@
 import { tables } from "../tables.ts";
-import { queryDb } from "@livestore/livestore";
+import { queryDb } from "@runtimed/schema";
 
 interface OutputDelta {
   id: string;

--- a/packages/schema/src/tables.ts
+++ b/packages/schema/src/tables.ts
@@ -1,4 +1,4 @@
-import { Schema, SessionIdSymbol, State } from "@livestore/livestore";
+import { Schema, SessionIdSymbol, State } from "@runtimed/schema";
 
 import {
   CellTypeSchema,

--- a/packages/schema/src/types.ts
+++ b/packages/schema/src/types.ts
@@ -1,4 +1,4 @@
-import { Schema } from "@runtimed/schemae";
+import { Schema } from "@livestore/livestore";
 
 // Media representation schema for unified output system - defined first for use in events
 export const MediaRepresentationSchema = Schema.Union(

--- a/packages/schema/src/types.ts
+++ b/packages/schema/src/types.ts
@@ -1,4 +1,4 @@
-import { Schema } from "@livestore/livestore";
+import { Schema } from "@runtimed/schemae";
 
 // Media representation schema for unified output system - defined first for use in events
 export const MediaRepresentationSchema = Schema.Union(

--- a/packages/schema/tsconfig.json
+++ b/packages/schema/tsconfig.json
@@ -10,7 +10,7 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "isolatedModules": true,
-    "lib": ["esnext"]
+    "lib": ["esnext", "dom"]
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "**/*.test.ts", "**/*.spec.ts"]

--- a/scripts/bump-schema-version.sh
+++ b/scripts/bump-schema-version.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Function to print colored output
+print_status() {
+    echo -e "${BLUE}[INFO]${NC} $1"
+}
+
+print_success() {
+    echo -e "${GREEN}[SUCCESS]${NC} $1"
+}
+
+print_warning() {
+    echo -e "${YELLOW}[WARNING]${NC} $1"
+}
+
+print_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+# Check if version argument is provided
+if [ $# -eq 0 ]; then
+    print_error "Usage: $0 <version>"
+    print_error "Example: $0 0.1.3"
+    exit 1
+fi
+
+NEW_VERSION="$1"
+SCHEMA_DIR="packages/schema"
+PACKAGE_JSON="$SCHEMA_DIR/package.json"
+JSR_JSON="$SCHEMA_DIR/jsr.json"
+
+# Validate version format (basic semver check)
+if ! echo "$NEW_VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?(\+[a-zA-Z0-9.-]+)?$'; then
+    print_error "Invalid version format: $NEW_VERSION"
+    print_error "Expected format: X.Y.Z (semver)"
+    exit 1
+fi
+
+print_status "Bumping schema package version to $NEW_VERSION"
+
+# Check if we're in the right directory
+if [ ! -f "$PACKAGE_JSON" ]; then
+    print_error "package.json not found at $PACKAGE_JSON"
+    print_error "Make sure you're running this from the anode root directory"
+    exit 1
+fi
+
+if [ ! -f "$JSR_JSON" ]; then
+    print_error "jsr.json not found at $JSR_JSON"
+    exit 1
+fi
+
+# Get current versions
+CURRENT_PACKAGE_VERSION=$(node -p "require('./$PACKAGE_JSON').version" 2>/dev/null || echo "unknown")
+CURRENT_JSR_VERSION=$(node -p "require('./$JSR_JSON').version" 2>/dev/null || echo "unknown")
+
+print_status "Current package.json version: $CURRENT_PACKAGE_VERSION"
+print_status "Current jsr.json version: $CURRENT_JSR_VERSION"
+
+# Check if versions are currently in sync
+if [ "$CURRENT_PACKAGE_VERSION" != "$CURRENT_JSR_VERSION" ]; then
+    print_warning "Current versions are out of sync!"
+fi
+
+# Update package.json
+print_status "Updating $PACKAGE_JSON..."
+if command -v jq >/dev/null 2>&1; then
+    # Use jq if available (preferred)
+    jq ".version = \"$NEW_VERSION\"" "$PACKAGE_JSON" > "${PACKAGE_JSON}.tmp" && mv "${PACKAGE_JSON}.tmp" "$PACKAGE_JSON"
+else
+    # Fallback to sed
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        # macOS
+        sed -i '' "s/\"version\": \".*\"/\"version\": \"$NEW_VERSION\"/" "$PACKAGE_JSON"
+    else
+        # Linux
+        sed -i "s/\"version\": \".*\"/\"version\": \"$NEW_VERSION\"/" "$PACKAGE_JSON"
+    fi
+fi
+
+# Update jsr.json
+print_status "Updating $JSR_JSON..."
+if command -v jq >/dev/null 2>&1; then
+    # Use jq if available (preferred)
+    jq ".version = \"$NEW_VERSION\"" "$JSR_JSON" > "${JSR_JSON}.tmp" && mv "${JSR_JSON}.tmp" "$JSR_JSON"
+else
+    # Fallback to sed
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        # macOS
+        sed -i '' "s/\"version\": \".*\"/\"version\": \"$NEW_VERSION\"/" "$JSR_JSON"
+    else
+        # Linux
+        sed -i "s/\"version\": \".*\"/\"version\": \"$NEW_VERSION\"/" "$JSR_JSON"
+    fi
+fi
+
+# Verify the changes
+UPDATED_PACKAGE_VERSION=$(node -p "require('./$PACKAGE_JSON').version")
+UPDATED_JSR_VERSION=$(node -p "require('./$JSR_JSON').version")
+
+if [ "$UPDATED_PACKAGE_VERSION" != "$NEW_VERSION" ] || [ "$UPDATED_JSR_VERSION" != "$NEW_VERSION" ]; then
+    print_error "Failed to update versions correctly"
+    print_error "package.json: $UPDATED_PACKAGE_VERSION"
+    print_error "jsr.json: $UPDATED_JSR_VERSION"
+    exit 1
+fi
+
+print_success "Successfully updated both files to version $NEW_VERSION"
+
+# Stage the changes
+if git status >/dev/null 2>&1; then
+    print_status "Staging changes..."
+    git add "$PACKAGE_JSON" "$JSR_JSON"
+
+    print_status "Changes staged. You can now commit with:"
+    echo "git commit -m \"Bump schema version to v$NEW_VERSION\""
+    echo "git tag v$NEW_VERSION"
+    echo "git push origin HEAD --tags"
+    print_warning "Remember: Pushing the tag will trigger the publish workflow!"
+else
+    print_warning "Not in a git repository. Changes made but not staged."
+fi
+
+# Show what changed
+print_status "Summary of changes:"
+echo "  $PACKAGE_JSON: $CURRENT_PACKAGE_VERSION → $NEW_VERSION"
+echo "  $JSR_JSON: $CURRENT_JSR_VERSION → $NEW_VERSION"
+
+print_success "Version bump complete!"

--- a/scripts/test-publish.sh
+++ b/scripts/test-publish.sh
@@ -1,0 +1,153 @@
+#!/bin/bash
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Function to print colored output
+print_status() {
+    echo -e "${BLUE}[INFO]${NC} $1"
+}
+
+print_success() {
+    echo -e "${GREEN}[SUCCESS]${NC} $1"
+}
+
+print_warning() {
+    echo -e "${YELLOW}[WARNING]${NC} $1"
+}
+
+print_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+print_step() {
+    echo ""
+    echo -e "${BLUE}=================================${NC}"
+    echo -e "${BLUE}$1${NC}"
+    echo -e "${BLUE}=================================${NC}"
+}
+
+# Check if we're in the right directory
+if [ ! -f "packages/schema/package.json" ]; then
+    print_error "packages/schema/package.json not found"
+    print_error "Make sure you're running this from the anode root directory"
+    exit 1
+fi
+
+print_step "Testing Schema Package Publish Process"
+
+# Step 1: Validate version consistency
+print_step "1. Validating Version Consistency"
+
+PACKAGE_VERSION=$(node -p "require('./packages/schema/package.json').version")
+JSR_VERSION=$(node -p "require('./packages/schema/jsr.json').version")
+
+print_status "package.json version: $PACKAGE_VERSION"
+print_status "jsr.json version: $JSR_VERSION"
+
+if [ "$PACKAGE_VERSION" != "$JSR_VERSION" ]; then
+    print_error "❌ Version mismatch: package.json ($PACKAGE_VERSION) != jsr.json ($JSR_VERSION)"
+    print_error "Run: pnpm bump-schema $PACKAGE_VERSION (or desired version)"
+    exit 1
+fi
+
+print_success "✅ Versions match: $PACKAGE_VERSION"
+
+# Step 2: Install dependencies if needed
+print_step "2. Checking Dependencies"
+
+if [ ! -d "node_modules" ]; then
+    print_status "Installing dependencies..."
+    pnpm install --frozen-lockfile
+else
+    print_success "Dependencies already installed"
+fi
+
+# Step 3: Type check
+print_step "3. Running Type Check"
+
+if pnpm --filter schema type-check; then
+    print_success "✅ Type check passed"
+else
+    print_error "❌ Type check failed"
+    exit 1
+fi
+
+# Step 4: Lint check
+print_step "4. Running Lint Check"
+
+if pnpm --filter schema lint:check; then
+    print_success "✅ Lint check passed"
+else
+    print_error "❌ Lint check failed"
+    exit 1
+fi
+
+# Step 5: Format check
+print_step "5. Running Format Check"
+
+if pnpm --filter schema format:check; then
+    print_success "✅ Format check passed"
+else
+    print_error "❌ Format check failed"
+    exit 1
+fi
+
+# Step 6: Test JSR publish (dry run)
+print_step "6. Testing JSR Publish (Dry Run)"
+
+# Check if jsr CLI is available
+if ! command -v jsr >/dev/null 2>&1; then
+    print_warning "jsr CLI not found, attempting to install globally..."
+    if ! npm install -g jsr; then
+        print_error "Failed to install jsr CLI"
+        print_error "Please install manually: npm install -g jsr"
+        exit 1
+    fi
+fi
+
+if pnpm --filter schema exec jsr publish --dry-run --allow-slow-types --allow-dirty; then
+    print_success "✅ JSR dry run successful"
+else
+    print_error "❌ JSR dry run failed"
+    exit 1
+fi
+
+# Step 7: Test npm publish (dry run)
+print_step "7. Testing npm Publish (Dry Run)"
+
+# Note: npm publish --dry-run requires being in the package directory
+cd packages/schema
+
+if npm publish --dry-run --access public; then
+    print_success "✅ npm dry run successful"
+else
+    print_error "❌ npm dry run failed"
+    exit 1
+fi
+
+cd ../..
+
+# Step 8: Show what would be published
+print_step "8. Summary"
+
+print_success "All checks passed! ✅"
+print_status "Package @runtimed/schema v$PACKAGE_VERSION is ready for publishing"
+print_status ""
+print_status "To publish for real:"
+print_status "1. Create and push a git tag:"
+print_status "   git tag v$PACKAGE_VERSION"
+print_status "   git push origin v$PACKAGE_VERSION"
+print_status ""
+print_status "2. Or publish manually:"
+print_status "   npm: pnpm --filter schema publish --access public"
+print_status "   jsr: pnpm --filter schema exec jsr publish --allow-slow-types"
+print_status ""
+print_warning "⚠️  Make sure you have NPM_TOKEN and JSR_TOKEN configured for manual publishing"
+
+print_step "Test Complete"

--- a/src/components/debug/DebugPanel.tsx
+++ b/src/components/debug/DebugPanel.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { useQuery, useStore } from "@livestore/react";
-import { queryDb, sql, Schema } from "@livestore/livestore";
+import { queryDb, sql, Schema } from "@runtimed/schema";
 
 import { tables, events, queries } from "@runtimed/schema";
 import { schema } from "@runtimed/schema";

--- a/src/components/livestore/CustomLiveStoreProvider.tsx
+++ b/src/components/livestore/CustomLiveStoreProvider.tsx
@@ -1,7 +1,7 @@
 import { schema } from "@runtimed/schema";
 import { makePersistedAdapter } from "@livestore/adapter-web";
 import LiveStoreSharedWorker from "@livestore/adapter-web/shared-worker?sharedworker";
-import { BootStatus } from "@livestore/livestore";
+import { BootStatus } from "@runtimed/schema";
 import { LiveStoreProvider } from "@livestore/react";
 import React, { useEffect, useMemo, useRef } from "react";
 import { unstable_batchedUpdates as batchUpdates } from "react-dom";

--- a/src/components/notebook/NotebookTitle.tsx
+++ b/src/components/notebook/NotebookTitle.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useState } from "react";
 import { useStore, useQuery } from "@livestore/react";
 import { events, tables } from "@runtimed/schema";
-import { queryDb } from "@livestore/livestore";
+import { queryDb } from "@runtimed/schema";
 import { Input } from "@/components/ui/input";
 
 interface NotebookTitleProps {

--- a/src/components/notebook/sidebar-panels/RuntimePanel.tsx
+++ b/src/components/notebook/sidebar-panels/RuntimePanel.tsx
@@ -5,7 +5,7 @@ import { getRuntimeCommand } from "@/util/runtime-command";
 import { Button } from "@/components/ui/button";
 import { Copy, Trash2 } from "lucide-react";
 import { events, tables } from "@runtimed/schema";
-import { queryDb } from "@livestore/livestore";
+import { queryDb } from "@runtimed/schema";
 import { useQuery, useStore } from "@livestore/react";
 import type { SidebarPanelProps } from "./types";
 import { useAuthenticatedUser } from "@/auth";

--- a/src/components/notebook/signals/ai-context.ts
+++ b/src/components/notebook/signals/ai-context.ts
@@ -1,4 +1,4 @@
-import { signal } from "@livestore/livestore";
+import { signal } from "@runtimed/schema";
 
 /**
  * Signal tracking whether AI context selection mode is active

--- a/src/components/notebook/signals/focus.ts
+++ b/src/components/notebook/signals/focus.ts
@@ -1,4 +1,4 @@
-import { signal } from "@livestore/livestore";
+import { signal } from "@runtimed/schema";
 
 /**
  * Signal tracking which cell is currently focused

--- a/src/hooks/useCellOutputs.tsx
+++ b/src/hooks/useCellOutputs.tsx
@@ -1,5 +1,5 @@
 import { OutputData, tables } from "@runtimed/schema";
-import { queryDb } from "@livestore/livestore";
+import { queryDb } from "@runtimed/schema";
 import { useQuery } from "@livestore/react";
 import { useState } from "react";
 

--- a/src/hooks/useCellPresence.ts
+++ b/src/hooks/useCellPresence.ts
@@ -1,5 +1,5 @@
 import { useQuery } from "@livestore/react";
-import { queryDb } from "@livestore/livestore";
+import { queryDb } from "@runtimed/schema";
 import { tables } from "@runtimed/schema";
 import { useCallback } from "react";
 

--- a/src/hooks/useEditorRegistry.ts
+++ b/src/hooks/useEditorRegistry.ts
@@ -1,6 +1,6 @@
 import { useCallback, useRef } from "react";
 import { useStore } from "@livestore/react";
-import { signal } from "@livestore/livestore";
+import { signal } from "@runtimed/schema";
 
 // Editor interface that we expect from CodeMirror editors
 export interface EditorRef {

--- a/src/hooks/useInterruptExecution.ts
+++ b/src/hooks/useInterruptExecution.ts
@@ -1,6 +1,6 @@
 import { useCallback } from "react";
 import { useStore, useQuery } from "@livestore/react";
-import { queryDb } from "@livestore/livestore";
+import { queryDb } from "@runtimed/schema";
 import { events, tables } from "@runtimed/schema";
 
 interface UseInterruptExecutionOptions {

--- a/src/hooks/useRuntimeHealth.ts
+++ b/src/hooks/useRuntimeHealth.ts
@@ -1,5 +1,5 @@
 import { useQuery } from "@livestore/react";
-import { queryDb } from "@livestore/livestore";
+import { queryDb } from "@runtimed/schema";
 import { RuntimeSessionData, tables } from "@runtimed/schema";
 import { useCallback } from "react";
 

--- a/src/hooks/useToolApprovals.ts
+++ b/src/hooks/useToolApprovals.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { useStore, useQuery } from "@livestore/react";
-import { queryDb } from "@livestore/livestore";
+import { queryDb } from "@runtimed/schema";
 import { events, tables } from "@runtimed/schema";
 import { useAuthenticatedUser } from "../auth/index.js";
 

--- a/src/hooks/useUserRegistry.ts
+++ b/src/hooks/useUserRegistry.ts
@@ -1,6 +1,6 @@
 import { useCallback, useMemo } from "react";
 import { useQuery } from "@livestore/react";
-import { queryDb } from "@livestore/livestore";
+import { queryDb } from "@runtimed/schema";
 import { tables } from "@runtimed/schema";
 
 import { generateInitials, generateColor } from "../util/avatar.js";

--- a/src/queries/index.ts
+++ b/src/queries/index.ts
@@ -1,5 +1,5 @@
 import { tables } from "@runtimed/schema";
-import { queryDb } from "@livestore/livestore";
+import { queryDb } from "@runtimed/schema";
 
 // Most queries come from `@runtimed/schema/queries`. Where we've needed something custom, we've written it here.
 

--- a/src/queries/outputDeltas.ts
+++ b/src/queries/outputDeltas.ts
@@ -1,5 +1,5 @@
 import { OutputData, tables } from "@runtimed/schema";
-import { queryDb } from "@livestore/livestore";
+import { queryDb } from "@runtimed/schema";
 
 // TODO: code here is duplicated from `runt/packages/schema/queries/outputDeltas.ts`
 // Reconcile it in the future

--- a/src/util/ai-models.ts
+++ b/src/util/ai-models.ts
@@ -1,5 +1,5 @@
 import { useQuery } from "@livestore/react";
-import { queryDb } from "@livestore/livestore";
+import { queryDb } from "@runtimed/schema";
 import { tables } from "@runtimed/schema";
 import { useMemo } from "react";
 

--- a/test/edge-cases.test.ts
+++ b/test/edge-cases.test.ts
@@ -5,7 +5,7 @@ import {
   createTestStoreId,
 } from "./setup.js";
 import { makeAdapter } from "@livestore/adapter-node";
-import { createStorePromise } from "@livestore/livestore";
+import { createStorePromise } from "@runtimed/schema";
 import { events, tables, schema } from "@runtimed/schema";
 
 console.log("🧪 Starting Anode edge case test suite...");

--- a/test/focused-cell-signal.test.ts
+++ b/test/focused-cell-signal.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { signal, createStorePromise } from "@livestore/livestore";
+import { signal, createStorePromise } from "@runtimed/schema";
 import { makeAdapter } from "@livestore/adapter-node";
 import { schema } from "@runtimed/schema";
 import { createTestStoreId, cleanupResources } from "./setup.js";

--- a/test/integration/execution-flow.test.ts
+++ b/test/integration/execution-flow.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { createStorePromise, queryDb } from "@livestore/livestore";
+import { createStorePromise, queryDb } from "@runtimed/schema";
 import { makeAdapter } from "@livestore/adapter-node";
 import { events, tables, schema } from "@runtimed/schema";
 import {

--- a/test/integration/reactivity-debugging.test.ts
+++ b/test/integration/reactivity-debugging.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { createStorePromise, queryDb } from "@livestore/livestore";
+import { createStorePromise, queryDb } from "@runtimed/schema";
 import { makeAdapter } from "@livestore/adapter-node";
 import { events, tables, schema } from "@runtimed/schema";
 import {


### PR DESCRIPTION
Publishing our schema from the comforts of anode.

Just to make sure everything keeps working I'm publishing this on npm and jsr as `@runtimed/schema`.

I'll be make `@runt/schema` depend on it in the runt repo shortly. I _think_ I'm going to have to re-export livestore bits from within it though just to make future transitions easier.

This is the pair PR to https://github.com/runtimed/runt/pull/214

Publish flow:

```
➜  anode git:(jsr-from-anode) pnpm bump-schema 0.1.7

> runt-ui@0.2.0 bump-schema /Users/kylekelley/code/src/github.com/runtimed/anode
> ./scripts/bump-schema-version.sh 0.1.7

[INFO] Bumping schema package version to 0.1.7
[INFO] Current package.json version: 0.1.6
[INFO] Current jsr.json version: 0.1.6
[INFO] Updating packages/schema/package.json...
[INFO] Updating packages/schema/jsr.json...
[SUCCESS] Successfully updated both files to version 0.1.7
[INFO] Staging changes...
[INFO] Changes staged. You can now commit with:
git commit -m "Bump schema version to v0.1.7"
git tag v0.1.7
git push origin HEAD --tags
[WARNING] Remember: Pushing the tag will trigger the publish workflow!
[INFO] Summary of changes:
  packages/schema/package.json: 0.1.6 → 0.1.7
  packages/schema/jsr.json: 0.1.6 → 0.1.7
[SUCCESS] Version bump complete!
➜  anode git:(jsr-from-anode) ✗ git pv
No changes.
[jsr-from-anode e6bdd86] publish 0.1.7
 2 files changed, 2 insertions(+), 2 deletions(-)
➜  anode git:(jsr-from-anode) git tag v0.1.7
➜  anode git:(jsr-from-anode) git push origin HEAD --tags
Enumerating objects: 19, done.
Counting objects: 100% (19/19), done.
Delta compression using up to 16 threads
Compressing objects: 100% (9/9), done.
Writing objects: 100% (11/11), 969 bytes | 969.00 KiB/s, done.
Total 11 (delta 6), reused 0 (delta 0), pack-reused 0
remote: Resolving deltas: 100% (6/6), completed with 5 local objects.
To github.com:runtimed/anode.git
   8aae26b..e6bdd86  HEAD -> jsr-from-anode
 * [new tag]         v0.1.7 -> v0.1.7
```
