### PR TITLE
Various tweaks that were too small to make PRs out of

### DIFF
--- a/.github/workflows/.deploy-reusable.yml
+++ b/.github/workflows/.deploy-reusable.yml
@@ -158,7 +158,7 @@ jobs:
             echo "- **Base App:** https://app.runt.run" >> $GITHUB_STEP_SUMMARY
             echo "- **Iframe Outputs:** https://runtusercontent.com" >> $GITHUB_STEP_SUMMARY
           else
-            echo "- **Preview App:** https://anode-preview.rgbkrk.workers.dev" >> $GITHUB_STEP_SUMMARY
+            echo "- **Preview App:** https://preview.runt.run" >> $GITHUB_STEP_SUMMARY
           fi
 
           echo "" >> $GITHUB_STEP_SUMMARY

--- a/src/components/notebooks/SharingModal.tsx
+++ b/src/components/notebooks/SharingModal.tsx
@@ -50,18 +50,20 @@ export const SharingModal: React.FC<SharingModalProps> = ({
   // Query for user by email using debounced value
   const { data: userByEmail, isFetching: lookingUpUser } = useQuery({
     ...trpc.userByEmail.queryOptions({ email: debouncedEmail.trim() }),
-    enabled: shouldLookupUser,
+    enabled: shouldLookupUser && isOpen,
   });
 
   // Query for notebook owner
-  const { data: owner } = useQuery(
-    trpc.notebookOwner.queryOptions({ nbId: notebook.id })
-  );
+  const { data: owner } = useQuery({
+    ...trpc.notebookOwner.queryOptions({ nbId: notebook.id }),
+    enabled: isOpen,
+  });
 
   // Query for notebook collaborators
-  const { data: collaborators, refetch: refetchCollaborators } = useQuery(
-    trpc.notebookCollaborators.queryOptions({ nbId: notebook.id })
-  );
+  const { data: collaborators, refetch: refetchCollaborators } = useQuery({
+    ...trpc.notebookCollaborators.queryOptions({ nbId: notebook.id }),
+    enabled: isOpen,
+  });
 
   // Share notebook mutation
   const shareMutation = useMutation(trpc.shareNotebook.mutationOptions());

--- a/src/components/notebooks/TagBadge.tsx
+++ b/src/components/notebooks/TagBadge.tsx
@@ -33,14 +33,14 @@ export const TagBadge: React.FC<TagBadgeProps> = ({ tag, className = "" }) => {
   return (
     <Badge
       variant="secondary"
-      className={`rounded-full border-0 px-2.5 py-0.5 text-xs font-medium ${className}`}
+      className={`max-w-full rounded-full border-0 px-2.5 py-0.5 text-xs font-medium ${className}`}
       data-tag-id={tag.id}
       style={{
         backgroundColor: tag.color,
         color: textColor,
       }}
     >
-      {tag.name}
+      <span className="truncate">{tag.name}</span>
     </Badge>
   );
 };

--- a/src/components/notebooks/dashboard/NotebookDashboard.tsx
+++ b/src/components/notebooks/dashboard/NotebookDashboard.tsx
@@ -76,8 +76,8 @@ export const NotebookDashboard: React.FC = () => {
 
         {/* Content Area */}
         <div className="flex-1 overflow-auto p-6">
-          {isLoading && <LoadingState message="Loading notebooks..." />}
           {debug.enabled && <DebugNotebooks notebooks={filteredNotebooks} />}
+          {isLoading && <LoadingState message="Loading notebooks..." />}
 
           {!isLoading && filteredNotebooks.length === 0 && <NoResults />}
 

--- a/src/components/outputs/MaybeCellOutputs.tsx
+++ b/src/components/outputs/MaybeCellOutputs.tsx
@@ -120,6 +120,7 @@ export const IframeOutput: React.FC<IframeOutputProps> = ({
       style={style}
       allow="accelerometer; autoplay; gyroscope; magnetometer; xr-spatial-tracking; clipboard-write; fullscreen"
       sandbox="allow-downloads allow-forms allow-pointer-lock allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts allow-storage-access-by-user-activation allow-modals allow-top-navigation-by-user-activation"
+      loading="lazy"
     />
   );
 };

--- a/src/components/outputs/shared-with-iframe/RichOutputContent.tsx
+++ b/src/components/outputs/shared-with-iframe/RichOutputContent.tsx
@@ -9,9 +9,6 @@ import {
   isAiToolCallData,
   isAiToolResultData,
 } from "@runtimed/schema";
-import { prefetchOutputsAdaptive } from "@/util/prefetch";
-
-prefetchOutputsAdaptive();
 
 // Dynamic imports for heavy components
 const MarkdownRenderer = React.lazy(() =>

--- a/src/components/outputs/shared-with-iframe/SuspenseSpinner.tsx
+++ b/src/components/outputs/shared-with-iframe/SuspenseSpinner.tsx
@@ -23,8 +23,8 @@ export function SuspenseSpinner({ children }: { children: React.ReactNode }) {
   return <Suspense fallback={<DelayedSpinner />}>{children}</Suspense>;
 }
 
-export const LoadingSpinner = ({ size = "md" }: { size?: SpinnerSize }) => (
-  <div className="flex items-center justify-center p-4">
+const LoadingSpinner = ({ size = "md" }: { size?: SpinnerSize }) => (
+  <div className="p-1 text-black/50">
     <Spinner size={size} />
   </div>
 );


### PR DESCRIPTION
## 2f6de59 Shorter suspense spinner
Spinner padding took up too much space and caused size to be too tall before getting short again

## 17e671d Lazy load iframe contents
https://web.dev/articles/iframe-lazy-loading

## 4a01f5a Remove prefetch in iframe
Lots of iframes cause ERR_INSUFFICIENT_RESOURCES

From Claude:
This `ERR_INSUFFICIENT_RESOURCES` error typically occurs when Chrome hits its limits for concurrent connections or resources.

In console:
```
GET http://localhost:8000/@fs/Users/mm/p/anode/node_modules/.vite/deps/chunk-TQJU5BCQ.js?v=a51594a7 net::ERR_INSUFFICIENT_RESOURCE
S
react-syntax-highlighter.js:571  GET http://localhost:8000/@fs/Users/mm/p/anode/node_modules/.vite/deps/chunk-JQOTC3DW.js?v=a51594
a7 net::ERR_INSUFFICIENT_RESOURCES
react-syntax-highlighter.js:574  GET http://localhost:8000/@fs/Users/mm/p/anode/node_modules/.vite/deps/chunk-4XOZMKWA.js?v=a51594
a7 net::ERR_INSUFFICIENT_RESOURCES
react-syntax-highlighter.js:577  GET http://localhost:8000/@fs/Users/mm/p/anode/node_modules/.vite/deps/chunk-2HD22A4U.js?v=a51594
a7 net::ERR_INSUFFICIENT_RESOURCES
react-syntax-highlighter.js?v=a51594a7:580  GET http://localhost:8000/@fs/Users/mm/p/anode/node_modules/.vite/deps/chunk-VJH5RYPL.
js?v=a51594a7 net::ERR_INSUFFICIENT_RESOURCES
```

## f0ce950 Tag badge support long text

Fixes this:
<img width="261" height="207" alt="Screenshot 2025-09-17 at 2 46 20 PM" src="https://github.com/user-attachments/assets/3d87ff8a-6be8-48cf-8cd5-ba40fa79c361" />

## 7fb22f2 Move loading lower than debug contents

## 2b7ae9d Update preview message GH actions

## 324d448 Fix sharing modal too many queries

Causes each notebook to make a trpc query from hidden modal