### PR TITLE
Allow workspace root install

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+# Enable workspace root installations
+ignore-workspace-root-check=true


### PR DESCRIPTION
`pnpm i -w left-pad` is a workaround that is ok in most case, but not sure if there is one when running shadcn commands like:
```sh
pnpm dlx shadcn@latest add alert
```