### PR TITLE
Cleanup play button and header

### DIFF
--- a/src/components/notebook/cell/ExecutableCell.tsx
+++ b/src/components/notebook/cell/ExecutableCell.tsx
@@ -350,7 +350,7 @@ export const ExecutableCell: React.FC<ExecutableCellProps> = ({
     >
       {/* Cell Header */}
       {!isSourceLessAiOutput && (
-        <div className="cell-header mb-2 flex items-center justify-between pr-1 pl-6 sm:pr-4">
+        <div className="cell-header flex items-center justify-between pr-1 pb-2 pl-6 sm:pr-4">
           <div className="flex items-center gap-3">
             <CellTypeSelector cell={cell} onCellTypeChange={changeCellType} />
 

--- a/src/components/notebook/cell/ExecutableCell.tsx
+++ b/src/components/notebook/cell/ExecutableCell.tsx
@@ -432,11 +432,10 @@ export const ExecutableCell: React.FC<ExecutableCellProps> = ({
               <PlayButton
                 executionState={cell.executionState}
                 cellType={cell.cellType}
-                autoFocus={autoFocus}
+                isFocused={autoFocus}
                 onExecute={executeCell}
                 onInterrupt={interruptCell}
                 className="mobile-play-btn block sm:hidden"
-                primaryColor="text-foreground"
               />
             }
           />
@@ -448,21 +447,20 @@ export const ExecutableCell: React.FC<ExecutableCellProps> = ({
         <div className="relative">
           {/* Play Button Breaking Through Left Border - Desktop Only */}
           <div
-            className="desktop-play-btn absolute -left-3 z-10 hidden sm:block"
+            className="absolute z-20 hidden -translate-x-1/2 sm:block"
             style={{
-              top: cell.sourceVisible ? "0.35rem" : "-1.5rem",
+              top: cell.sourceVisible ? "0.35rem" : "-2.1rem",
             }}
           >
             <PlayButton
               executionState={cell.executionState}
               cellType={cell.cellType}
-              autoFocus={autoFocus}
+              isFocused={autoFocus}
               onExecute={executeCell}
               onInterrupt={interruptCell}
-              size="default"
-              className="h-6 w-6 rounded-sm border-0 bg-white p-0 transition-colors hover:bg-white"
-              primaryColor={
-                cell.cellType === "ai" ? "text-purple-600" : "text-foreground"
+              className="desktop-play-btn"
+              focusedClass={
+                cell.cellType === "ai" ? "text-purple-600" : undefined
               }
             />
           </div>

--- a/src/components/notebook/cell/MarkdownCell.tsx
+++ b/src/components/notebook/cell/MarkdownCell.tsx
@@ -247,7 +247,7 @@ export const MarkdownCell: React.FC<MarkdownCellProps> = ({
     >
       {/* Cell Header */}
       <div
-        className="cell-header mb-2 flex items-center justify-between pr-1 pl-6 sm:pr-4"
+        className="cell-header flex items-center justify-between pr-1 pb-2 pl-6 sm:pr-4"
         onKeyDown={!isEditing ? handleKeyDown : undefined}
       >
         <div className="flex items-center gap-3">
@@ -293,8 +293,9 @@ export const MarkdownCell: React.FC<MarkdownCellProps> = ({
       <div className="relative">
         <div
           className={cn(
-            "cell-content bg-white py-1 pr-4 pl-4 transition-colors",
-            cell.sourceVisible && !isEditing ? "h-auto" : "h-0 opacity-0"
+            "cell-content bg-white pr-4 pl-4 transition-colors",
+            // Ensure we don't add to parent height if hidden
+            cell.sourceVisible && !isEditing ? "h-auto py-1" : "h-0 opacity-0"
           )}
         >
           {/* Send markdown content to iframe */}
@@ -329,8 +330,9 @@ export const MarkdownCell: React.FC<MarkdownCellProps> = ({
         {/* Editor Content Area */}
         <div
           className={cn(
-            "cell-content bg-white py-1 pl-4 transition-colors",
-            cell.sourceVisible && isEditing ? "block" : "hidden"
+            "cell-content bg-white pl-4 transition-colors",
+            // Ensure we don't add to parent height if hidden
+            cell.sourceVisible && isEditing ? "block py-1" : "hidden"
           )}
         >
           <ErrorBoundary fallback={<div>Error rendering editor</div>}>

--- a/src/components/notebook/cell/shared/CellContainer.tsx
+++ b/src/components/notebook/cell/shared/CellContainer.tsx
@@ -30,9 +30,7 @@ export const CellContainer = forwardRef<HTMLDivElement, CellContainerProps>(
         ref={ref}
         data-cell-id={cell.id}
         className={`cell-container group relative pt-2 transition-all duration-200 ${
-          autoFocus && !contextSelectionMode
-            ? focusBgColor
-            : "hover:bg-muted/10"
+          autoFocus && !contextSelectionMode ? focusBgColor : "hover:bg-gray-50"
         } ${contextSelectionMode && !cell.aiContextVisible ? "opacity-60" : ""} ${
           contextSelectionMode
             ? cell.aiContextVisible

--- a/src/components/notebook/cell/shared/PlayButton.tsx
+++ b/src/components/notebook/cell/shared/PlayButton.tsx
@@ -1,62 +1,46 @@
+import { cn } from "@/lib/utils";
+import { Play, Square } from "lucide-react";
 import React from "react";
-import { Button } from "@/components/ui/button";
-import { Square, Play } from "lucide-react";
 
 interface PlayButtonProps {
   executionState: "idle" | "queued" | "running" | "completed" | "error";
   cellType: string;
-  autoFocus?: boolean;
+  isFocused?: boolean;
   onExecute: () => void;
   onInterrupt: () => void;
   className?: string;
-  size?: "sm" | "default";
-  primaryColor?: string;
+  focusedClass?: string;
 }
 
 export const PlayButton: React.FC<PlayButtonProps> = ({
   executionState,
   cellType,
-  autoFocus = false,
+  isFocused = false,
   onExecute,
   onInterrupt,
   className = "",
-  size = "sm",
-  primaryColor = "text-foreground",
+  focusedClass = "text-foreground",
 }) => {
   const isRunning = executionState === "running" || executionState === "queued";
-
-  const getExecuteTitle = () => {
-    if (executionState === "running" || executionState === "queued") {
-      return "Stop execution";
-    }
-    return `Execute ${cellType} cell`;
-  };
-
-  const getPlayButtonContent = () => {
-    if (executionState === "running") {
-      return <Square className="h-3 w-3" />;
-    }
-    if (executionState === "queued") {
-      return <Square className="h-3 w-3" />;
-    }
-    return <Play className="h-4 w-4" />;
-  };
+  const title = isRunning ? "Stop execution" : `Execute ${cellType} cell`;
 
   return (
-    <Button
-      variant="ghost"
-      size={size}
+    <button
       onClick={isRunning ? onInterrupt : onExecute}
-      className={`${
-        size === "sm" ? "h-8 w-8 p-0 sm:hidden" : "h-6 w-6 p-0"
-      } hover:bg-muted/80 ${
-        autoFocus
-          ? primaryColor
-          : "text-muted-foreground/40 hover:text-foreground group-hover:text-foreground"
-      } ${className}`}
-      title={getExecuteTitle()}
+      className={cn(
+        "hover:bg-muted/80 flex items-center justify-center rounded-sm bg-white p-1 transition-colors",
+        isFocused
+          ? focusedClass
+          : "text-muted-foreground/40 hover:text-foreground group-hover:text-foreground",
+        className
+      )}
+      title={title}
     >
-      {getPlayButtonContent()}
-    </Button>
+      {isRunning ? (
+        <Square fill="white" className="size-4" />
+      ) : (
+        <Play fill="white" className="size-4" />
+      )}
+    </button>
   );
 };


### PR DESCRIPTION
Mostly refactored play button styling. Some minor adjustments to the header.

Also works fine when cell collapsed (see play button centering and hover):

https://github.com/user-attachments/assets/cbe4f9d0-7195-454f-a45c-b3081fda3a47

Hover for markdown cells used to have extra bottom padding