### PR TITLE
Fix LiveStore first vs select all out of sync

### DIFF
--- a/src/components/notebook/NotebookContent.tsx
+++ b/src/components/notebook/NotebookContent.tsx
@@ -1,5 +1,5 @@
 import { useQuery, useStore } from "@livestore/react";
-import { CellReference, queries } from "@runtimed/schema";
+import { CellData, queries } from "@runtimed/schema";
 import React from "react";
 import { ErrorBoundary } from "react-error-boundary";
 import { Cell } from "./cell/Cell.js";
@@ -11,7 +11,7 @@ import { focusedCellSignal$, hasManuallyFocused$ } from "./signals/focus.js";
 
 export const NotebookContent = () => {
   const { store } = useStore();
-  const cellReferences = useQuery(queries.cellsWithIndices$);
+  const cellReferences = useQuery(queries.cells$);
 
   const focusedCellId = useQuery(focusedCellSignal$);
   const hasManuallyFocused = useQuery(hasManuallyFocused$);
@@ -38,7 +38,7 @@ export const NotebookContent = () => {
       ) : (
         <>
           <ErrorBoundary fallback={<div>Error rendering cell list</div>}>
-            <CellList cellReferences={cellReferences} />
+            <CellList cells={cellReferences} />
           </ErrorBoundary>
           {/* Add Cell Buttons */}
           <div className="border-border/30 mt-6 border-t px-4 pt-4 sm:mt-8 sm:px-0 sm:pt-6">
@@ -56,27 +56,25 @@ export const NotebookContent = () => {
 };
 
 interface CellListProps {
-  cellReferences: readonly CellReference[];
+  cells: readonly CellData[];
 }
 
-export const CellList: React.FC<CellListProps> = ({ cellReferences }) => {
+export const CellList: React.FC<CellListProps> = ({ cells }) => {
   const focusedCellId = useQuery(focusedCellSignal$);
   const contextSelectionMode = useQuery(contextSelectionMode$);
 
   return (
     <div style={{ paddingLeft: "1rem" }}>
-      {cellReferences.map((cellReference, index) => (
-        <div key={cellReference.id}>
+      {cells.map((cell, index) => (
+        <div key={cell.id}>
           <ErrorBoundary fallback={<div>Error rendering cell</div>}>
-            {index === 0 && (
-              <CellBetweener cell={cellReference} position="before" />
-            )}
+            {index === 0 && <CellBetweener cell={cell} position="before" />}
             <Cell
-              cellId={cellReference.id}
-              isFocused={cellReference.id === focusedCellId}
+              cell={cell}
+              isFocused={cell.id === focusedCellId}
               contextSelectionMode={contextSelectionMode}
             />
-            <CellBetweener cell={cellReference} position="after" />
+            <CellBetweener cell={cell} position="after" />
           </ErrorBoundary>
         </div>
       ))}

--- a/src/components/notebook/cell/Cell.tsx
+++ b/src/components/notebook/cell/Cell.tsx
@@ -1,20 +1,17 @@
-import { queries } from "@runtimed/schema";
+import { CellData } from "@runtimed/schema";
 import React, { memo } from "react";
 import { ErrorBoundary } from "react-error-boundary";
-import { useQuery } from "@livestore/react";
 import { ExecutableCell } from "./ExecutableCell.js";
 import { MarkdownCell } from "./MarkdownCell.js";
 
 interface CellProps {
-  cellId: string;
+  cell: CellData;
   isFocused: boolean;
   contextSelectionMode: boolean;
 }
 
 export const Cell: React.FC<CellProps> = memo(
-  ({ cellId, isFocused, contextSelectionMode }) => {
-    const cell = useQuery(queries.cellQuery.byId(cellId));
-
+  ({ cell, isFocused, contextSelectionMode }) => {
     if (!cell) {
       console.warn("Asked to render a cell that does not exist");
       return null;


### PR DESCRIPTION
Done by not using the `.byId` helper function.

This is for cell ordering. Individual queries get out of sync with the the full nb query:

https://github.com/runtimed/anode/pull/576

Perf looks fine with about 15 cells