### PR TITLE
Fix Anaconda AI provider initialization with auth tokens

### DIFF
--- a/src/runtime/ai-provider.ts
+++ b/src/runtime/ai-provider.ts
@@ -403,10 +403,8 @@ class AIProviderRegistry {
       console.log("🔄 Updating AI provider with refreshed auth token");
       this.currentAuthToken = token;
 
-      // Re-initialize the current provider with the new token
-      if (this.currentProvider) {
-        this.initializeFromEnvironment();
-      }
+      // Re-initialize with the new token (regardless of previous provider state)
+      this.initializeFromEnvironment();
     }
   }
 }


### PR DESCRIPTION
- Fix `updateAuthToken()` to always re-initialize provider regardless of previous state
- Add comprehensive debug logging to `AuthAwareAIProvider`
- Resolves issue where AI provider failed to initialize after auth completion

Fixes: 'Unknown AI provider: anaconda' and 'No models available' errors