### PR TITLE
show all results on the scratch page

### DIFF
--- a/src/components/notebooks/dashboard/NotebookDashboard.tsx
+++ b/src/components/notebooks/dashboard/NotebookDashboard.tsx
@@ -36,7 +36,6 @@ export const NotebookDashboard: React.FC = () => {
   const {
     allNotebooks,
     filteredNotebooks,
-    recentScratchNotebooks,
     namedNotebooks,
     isLoading,
     error,
@@ -94,7 +93,6 @@ export const NotebookDashboard: React.FC = () => {
           {!isLoading && filteredNotebooks.length > 0 && (
             <Results
               refetch={refetch}
-              recentScratchNotebooks={recentScratchNotebooks}
               namedNotebooks={namedNotebooks}
               filteredNotebooks={filteredNotebooks}
             />

--- a/src/components/notebooks/dashboard/Results.tsx
+++ b/src/components/notebooks/dashboard/Results.tsx
@@ -5,17 +5,15 @@ import { useTrpc } from "@/components/TrpcProvider";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { useQuery } from "@tanstack/react-query";
-import { Clock, Plus, Search, Tag, Users, X } from "lucide-react";
+import { Plus, Search, Tag, Users, X } from "lucide-react";
 import { useCreateNotebookAndNavigate, useDashboardParams } from "./helpers";
 
 export function Results({
   refetch,
-  recentScratchNotebooks,
   namedNotebooks,
   filteredNotebooks,
 }: {
   refetch: () => void;
-  recentScratchNotebooks: NotebookProcessed[];
   namedNotebooks: NotebookProcessed[];
   filteredNotebooks: NotebookProcessed[];
 }) {
@@ -102,9 +100,7 @@ export function Results({
               <h2 className="text-lg font-semibold text-gray-900">
                 {activeFilter === "shared"
                   ? "Shared with Me"
-                  : activeFilter === "scratch"
-                    ? "All Scratch Work"
-                    : "All My Notebooks"}
+                  : "All My Notebooks"}
               </h2>
               <Badge variant="secondary" className="ml-2">
                 {filteredNotebooks.length}

--- a/src/hooks/use-notebooks.ts
+++ b/src/hooks/use-notebooks.ts
@@ -65,74 +65,59 @@ export function useNotebooks(
   }, [notebooksData, userData]);
 
   // Filter and group notebooks
-  const { filteredNotebooks, recentScratchNotebooks, namedNotebooks } =
-    useMemo(() => {
-      // Apply tag filter first to create base set
-      let baseFiltered = allNotebooks;
-      if (selectedTagName) {
-        baseFiltered = baseFiltered.filter((n: NotebookProcessed) =>
-          n.tags?.some((tag: any) => tag.name === selectedTagName)
-        );
-      }
+  const { filteredNotebooks, namedNotebooks } = useMemo(() => {
+    // Apply tag filter first to create base set
+    let baseFiltered = allNotebooks;
+    if (selectedTagName) {
+      baseFiltered = baseFiltered.filter((n: NotebookProcessed) =>
+        n.tags?.some((tag: any) => tag.name === selectedTagName)
+      );
+    }
 
-      // Apply activeFilter to baseFiltered
-      let filtered = baseFiltered;
-      if (activeFilter === "scratch") {
-        filtered = filtered.filter(
-          (n: NotebookProcessed) =>
-            n.myPermission === "OWNER" &&
-            (!n.title || n.title.startsWith("Untitled"))
-        );
-      } else if (activeFilter === "named") {
-        filtered = filtered.filter(
-          (n: NotebookProcessed) =>
-            n.myPermission === "OWNER" &&
-            n.title &&
-            !n.title.startsWith("Untitled")
-        );
-      } else if (activeFilter === "shared") {
-        filtered = filtered.filter(
-          (n: NotebookProcessed) => n.myPermission === "WRITER"
-        );
-      }
-
-      // Apply search
-      if (searchQuery.trim()) {
-        const query = searchQuery.toLowerCase();
-        filtered = filtered.filter((n: NotebookProcessed) =>
-          n.title?.toLowerCase().includes(query)
-        );
-      }
-
-      // Group scratch notebooks by recency (last 7 days) for scratch view
-      const sevenDaysAgo = new Date();
-      sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
-
-      const recentScratch = filtered.filter(
+    // Apply activeFilter to baseFiltered
+    let filtered = baseFiltered;
+    if (activeFilter === "scratch") {
+      filtered = filtered.filter(
         (n: NotebookProcessed) =>
-          new Date(n.updated_at) > sevenDaysAgo &&
+          n.myPermission === "OWNER" &&
           (!n.title || n.title.startsWith("Untitled"))
       );
-
-      // All named notebooks from tag-filtered base (respects tag filter)
-      const named = baseFiltered.filter(
+    } else if (activeFilter === "named") {
+      filtered = filtered.filter(
         (n: NotebookProcessed) =>
           n.myPermission === "OWNER" &&
           n.title &&
           !n.title.startsWith("Untitled")
       );
+    } else if (activeFilter === "shared") {
+      filtered = filtered.filter(
+        (n: NotebookProcessed) => n.myPermission === "WRITER"
+      );
+    }
 
-      return {
-        filteredNotebooks: filtered,
-        recentScratchNotebooks: recentScratch,
-        namedNotebooks: named,
-      };
-    }, [allNotebooks, activeFilter, searchQuery, selectedTagName]);
+    // Apply search
+    if (searchQuery.trim()) {
+      const query = searchQuery.toLowerCase();
+      filtered = filtered.filter((n: NotebookProcessed) =>
+        n.title?.toLowerCase().includes(query)
+      );
+    }
+
+    // All named notebooks from tag-filtered base (respects tag filter)
+    const named = baseFiltered.filter(
+      (n: NotebookProcessed) =>
+        n.myPermission === "OWNER" && n.title && !n.title.startsWith("Untitled")
+    );
+
+    return {
+      filteredNotebooks: filtered,
+      namedNotebooks: named,
+    };
+  }, [allNotebooks, activeFilter, searchQuery, selectedTagName]);
 
   return {
     allNotebooks,
     filteredNotebooks,
-    recentScratchNotebooks,
     namedNotebooks,
     isLoading: isLoading,
     error,


### PR DESCRIPTION
It was totally misleading to see the total count of scratch on the left and only recent on the right

<img width="1188" height="350" alt="image" src="https://github.com/user-attachments/assets/c6ebe149-1cbe-4da9-993c-fac04635c3de" />

This just shows all of them now.
