### PR TITLE
Fix markdown single $ rendering as inline latex

### DIFF
--- a/src/components/outputs/shared-with-iframe/MarkdownRenderer.tsx
+++ b/src/components/outputs/shared-with-iframe/MarkdownRenderer.tsx
@@ -83,6 +83,14 @@ const generateSlug = (text: string): string => {
     .trim();
 };
 
+const remarkMathOptions = {
+  /**
+   * Single dollar symbol to render inline epxressions in Math often interferes with “normal” dollars in text.
+   * We turn this off so we use two-dollar symbols ($$) instead
+   */
+  singleDollarTextMath: false,
+};
+
 export const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
   content,
   className = "prose prose-sm max-w-none prose-gray",
@@ -92,7 +100,7 @@ export const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
   return (
     <div className={`${className} [&_pre]:!bg-gray-50`}>
       <ReactMarkdown
-        remarkPlugins={[remarkGfm, remarkMath]}
+        remarkPlugins={[remarkGfm, [remarkMath, remarkMathOptions]]}
         rehypePlugins={[rehypeKatex, rehypeRaw]}
         components={{
           a({ href, children, ...props }) {


### PR DESCRIPTION
Before, this would render like so

```
Lift($L$) can be determined by Lift Coefficient ($C_L$) like the following
equation.

$$
L = \frac{1}{2} \rho v^2 S C_L
$$
```

<img width="706" height="157" alt="Screenshot 2025-10-03 at 10 23 07 AM" src="https://github.com/user-attachments/assets/eaab80cf-49f6-4ea2-8f90-6c580fffa76c" />

But it would break for other scenarios (Jupyter also breaks the same way):

<img width="715" height="248" alt="Screenshot 2025-10-03 at 11 05 05 AM" src="https://github.com/user-attachments/assets/8da6ad5d-afb4-42db-87d6-4acdc5e2b0dc" />

After, we require double `$$` even for inline math:

```
Lift($$L$$) can be determined by Lift Coefficient ($$C_L$$) like the following
equation.

$$
L = \frac{1}{2} \rho v^2 S C_L
$$
```

<img width="706" height="157" alt="Screenshot 2025-10-03 at 10 23 07 AM" src="https://github.com/user-attachments/assets/eaab80cf-49f6-4ea2-8f90-6c580fffa76c" />

https://github.com/orgs/remarkjs/discussions/1229

Other related issues:

- https://github.com/remarkjs/remark-math/issues/63

- https://github.com/remarkjs/remark-math/issues/21

- https://github.com/remarkjs/remark-math/issues/8