### PR TITLE
send time zone marker with updated_at and created_at time info

### DIFF
--- a/backend/notebook-permissions/local-permissions.ts
+++ b/backend/notebook-permissions/local-permissions.ts
@@ -378,7 +378,9 @@ export class LocalPermissionsProvider implements PermissionsProvider {
       if (owned && !shared) {
         // Only owned notebooks
         query = `
-          SELECT id, owner_id, title, created_at, updated_at
+          SELECT id, owner_id, title,
+            strftime('%Y-%m-%dT%H:%M:%SZ', created_at) as created_at,
+            strftime('%Y-%m-%dT%H:%M:%SZ', updated_at) as updated_at
           FROM notebooks
           WHERE owner_id = ?
           ORDER BY updated_at DESC
@@ -388,7 +390,9 @@ export class LocalPermissionsProvider implements PermissionsProvider {
       } else if (shared && !owned) {
         // Only shared notebooks (writer permissions)
         query = `
-          SELECT n.id, n.owner_id, n.title, n.created_at, n.updated_at
+          SELECT n.id, n.owner_id, n.title,
+            strftime('%Y-%m-%dT%H:%M:%SZ', n.created_at) as created_at,
+            strftime('%Y-%m-%dT%H:%M:%SZ', n.updated_at) as updated_at
           FROM notebooks n
           INNER JOIN notebook_permissions np ON n.id = np.notebook_id
           WHERE np.user_id = ? AND np.permission = 'writer'
@@ -399,7 +403,9 @@ export class LocalPermissionsProvider implements PermissionsProvider {
       } else {
         // All accessible notebooks (owned + shared)
         query = `
-          SELECT DISTINCT n.id, n.owner_id, n.title, n.created_at, n.updated_at
+          SELECT DISTINCT n.id, n.owner_id, n.title,
+            strftime('%Y-%m-%dT%H:%M:%SZ', n.created_at) as created_at,
+            strftime('%Y-%m-%dT%H:%M:%SZ', n.updated_at) as updated_at
           FROM notebooks n
           LEFT JOIN notebook_permissions np ON n.id = np.notebook_id
           WHERE n.owner_id = ? OR (np.user_id = ? AND np.permission = 'writer')


### PR DESCRIPTION
Fixes https://github.com/runtimed/intheloop/issues/637

Before:
<img width="393" height="194" alt="image" src="https://github.com/user-attachments/assets/3f79196c-299a-46db-8da6-e1e7092ce7a1" />

After:
<img width="390" height="186" alt="image" src="https://github.com/user-attachments/assets/635bb740-9b42-49ba-9ca0-9a0465d092d6" />


The backend stores created/updated times in UTC, but the timestamp format used doesn't include a time zone indicator. In most places, when the backend reads timestamps from the database, it converts those timestamps to the format I'm using here, which adds a `Z` to the end of the timestamp, indicating the time zone is UTC.

When the format conversion does not happen, and the time stamp is sent over without a time zone indicator, client libraries interpret the time as being local time. So if I update a notebook at 12:00 UTC, client libraries can interpret that as being updated at 12:00 PST. The solution is to always ensure we do the format conversion on the backend, so client libraries read the time zone correctly.