### PR TITLE
Add error boundary to notebook preview

### DIFF
--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -76,6 +76,9 @@ export { groupConsecutiveStreamOutputs } from "./utils/output-grouping.js";
 export { OutputTypesDemoPage } from "./OutputTypesDemoPage.js";
 export { Incrementor } from "./Incrementor.js";
 
+// Error boundary
+export { ErrorBoundary } from "react-error-boundary";
+
 // Re-export types from schema for convenience
 export type {
   OutputData,


### PR DESCRIPTION
## Summary
- Wrap notebook preview rendering components (`SyntaxHighlighter`, `OutputsContainer`, `MarkdownCell`, and the top-level cell list) in `ErrorBoundary` from `react-error-boundary` to prevent individual cell/output rendering failures from crashing the entire preview
- Re-export `ErrorBoundary` from `@runtimed/components` for shared use

## Test plan
- [ ] Verify notebook preview renders normally with no regressions
- [ ] Confirm that a rendering error in one cell is caught and displays a fallback message without breaking the rest of the notebook


Made with [Cursor](https://cursor.com)